### PR TITLE
Add first iteration of spawn limit calculation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import driveCreep from './modules/creepDriver';
 import { manageMemory } from './modules/memoryManagement';
-import populationControl from './modules/populationControl';
+import { populationControl } from './modules/populationControl';
 import driveRoom from './modules/roomDriver';
 require('./prototypes/requirePrototypes');
 

--- a/src/modules/populationControl.ts
+++ b/src/modules/populationControl.ts
@@ -66,8 +66,8 @@ export function calculateCreepCapacity(room: Room): number {
     let workPartsNeeded = sourceCount * workPartsPerSource;
     let creepsNeeded = Math.ceil(workPartsNeeded / maxWorkPartsPerCreep);
 
-    //creepsNeeded is likely to be VERY HIGH in early rooms (higher than the access point count may be able to accommodate), so cap at 2.5 access point count
-    let restrictedCapacty = Math.ceil(accessPointCount * 2.5);
+    //creepsNeeded is likely to be VERY HIGH in early rooms (higher than the access point count may be able to accommodate), so cap based on access point count
+    let restrictedCapacty = Math.ceil(accessPointCount * 2);
     let creepCapacity = restrictedCapacty < creepsNeeded ? restrictedCapacty : creepsNeeded;
 
     return creepCapacity;

--- a/src/modules/populationControl.ts
+++ b/src/modules/populationControl.ts
@@ -1,9 +1,8 @@
-export default function populationControl(spawn: StructureSpawn) {
-    //arbitrary spawn limits until further notice
-    const SPAWN_LIMIT = spawn.room.memory.sourceAccessPointCount * 2;
+export function populationControl(spawn: StructureSpawn) {
+    const SPAWN_LIMIT = calculateCreepCapacity(spawn.room);
     const WORKER_LIMIT = SPAWN_LIMIT / 2;
-    const UPGRADER_LIMIT = SPAWN_LIMIT / 4;
-    const MAINTAINTER_LIMIT = SPAWN_LIMIT / 4;
+    const UPGRADER_LIMIT = Math.floor(SPAWN_LIMIT / 4);
+    const MAINTAINTER_LIMIT = Math.floor(SPAWN_LIMIT / 4);
 
     let roomCreeps = Object.values(Game.creeps).filter((creep) => creep.memory.room === spawn.room.name);
 
@@ -32,7 +31,7 @@ export default function populationControl(spawn: StructureSpawn) {
 
         let result = spawn.spawnCreep(partsArray, `${options.memory.role} ${Game.time}`, options);
 
-        //if there are no harvesters, and there is not enough energy to spawn one
+        //if there are no worker, and there is not enough energy to spawn one immediately, convert another creep to worker
         if (result === ERR_NOT_ENOUGH_ENERGY && options.memory.role === Role.WORKER) {
             let potentialWorkers = roomCreeps.filter((creep) => creep.memory.role !== Role.WORKER && creep.getActiveBodyparts(WORK));
             if (potentialWorkers.length) {
@@ -40,11 +39,36 @@ export default function populationControl(spawn: StructureSpawn) {
                 creepToConvert.memory.role = Role.WORKER;
                 creepToConvert.memory.targetId = null;
             } else if (roomCreeps.filter((creep) => creep.memory.role === Role.WORKER).length) {
-                //spawn first available harvester
+                //spawn first available worker
                 partsArray = [];
                 for (let i = 0; i < Math.floor(spawn.room.energyAvailable / 200); i++) partsArray = partsArray.concat(partsBlock);
                 spawn.spawnCreep(partsArray, `${options.memory.role} ${Game.time}`, options);
             }
         }
     }
+}
+
+// function to calculate how many creeps a room can support
+export function calculateCreepCapacity(room: Room): number {
+    //potentially useful values
+    let sourceCount = room.find(FIND_SOURCES).length;
+    let accessPointCount = room.memory.sourceAccessPointCount;
+    let maxEnergy = room.energyCapacityAvailable;
+
+    //sources have 3k energy per 300 ticks -> 10 energy per tick
+    //creeps harvest 2 energy per tick per WORK ==> 5 work blocks per source for 100% efficiency
+    //let us assume creeps will spend approximately half of their time working (not mining) => 10 work blocks per source
+    let workPartsPerSource = 10;
+
+    //cost to create [WORK, CARRY, MOVE] is 200 energy
+    let maxWorkPartsPerCreep = Math.floor(maxEnergy / 200);
+
+    let workPartsNeeded = sourceCount * workPartsPerSource;
+    let creepsNeeded = Math.ceil(workPartsNeeded / maxWorkPartsPerCreep);
+
+    //creepsNeeded is likely to be VERY HIGH in early rooms (higher than the access point count may be able to accommodate), so cap at 2.5 access point count
+    let restrictedCapacty = Math.ceil(accessPointCount * 2.5);
+    let creepCapacity = restrictedCapacty < creepsNeeded ? restrictedCapacty : creepsNeeded;
+
+    return creepCapacity;
 }


### PR DESCRIPTION
This should hopefully make spawning and creep amounts pretty efficient for the first phase of room life.