### PR TITLE
Add completion checks to jobs

### DIFF
--- a/src/modules/WaveCreep.ts
+++ b/src/modules/WaveCreep.ts
@@ -8,7 +8,7 @@ export class WaveCreep extends Creep {
     private claimSourceAccessPoint() {
         if (this.room.memory.availableSourceAccessPoints.length) {
             let accessPoints = this.room.memory.availableSourceAccessPoints.map((s) => posFromMem(s));
-            let closest = this.pos.findClosestByPath(accessPoints);
+            let closest = this.pos.findClosestByPath(accessPoints, {ignoreCreeps: true});
             this.memory.miningPos = closest.toMemSafe();
 
             let index = accessPoints.findIndex((pos) => pos.isEqualTo(closest));
@@ -134,18 +134,12 @@ export class WaveCreep extends Creep {
 
     private isRepairFinished(target: Structure): boolean {
         let workValue = this.getActiveBodyparts(WORK) * REPAIR_POWER;
-        if (target.hits >= target.hitsMax - workValue) {
-            return true;
-        }
-        return false;
+        return target.hits >= target.hitsMax - workValue
     }
 
     private isBuildFinished(target: ConstructionSite): boolean {
         let workValue = this.getActiveBodyparts(WORK) * BUILD_POWER;
-        if (target.progress >= target.progressTotal - workValue) {
-            return true;
-        }
-        return false;
+        return target.progress >= target.progressTotal - workValue
     }
 
     private usedAllRemainingEnergy(energyUsedPerWork: number){

--- a/src/modules/WaveCreep.ts
+++ b/src/modules/WaveCreep.ts
@@ -52,7 +52,9 @@ export class WaveCreep extends Creep {
     }
 
     protected runBuildJob(target: ConstructionSite) {
-        switch (this.build(target)) {
+        let jobCost = BUILD_POWER * this.getActiveBodyparts(WORK);
+        let buildSuccess = this.build(target);
+        switch (buildSuccess) {
             case ERR_NOT_IN_RANGE:
                 this.travelTo(target, { visualizePathStyle: { stroke: '#ffffff' } });
                 break;
@@ -61,10 +63,20 @@ export class WaveCreep extends Creep {
             case ERR_INVALID_TARGET:
                 delete this.memory.targetId;
                 break;
+            case OK:
+                if(this.isBuildFinished(target)){
+                    delete this.memory.targetId;
+                }
+                if(this.usedAllRemainingEnergy(jobCost)){
+                    this.memory.gathering = true;
+                    delete this.memory.targetId;
+                }
+                break;
         }
     }
 
     protected runUpgradeJob() {
+        let jobCost = UPGRADE_CONTROLLER_POWER * this.getActiveBodyparts(WORK);
         switch (this.upgradeController(Game.rooms[this.memory.room].controller)) {
             case ERR_NOT_IN_RANGE:
                 this.travelTo(Game.rooms[this.memory.room].controller, { visualizePathStyle: { stroke: '#ffffff' } });
@@ -72,6 +84,12 @@ export class WaveCreep extends Creep {
             case ERR_NOT_ENOUGH_RESOURCES:
                 this.memory.gathering = true;
                 delete this.memory.targetId;
+                break;
+            case OK:
+                if(this.usedAllRemainingEnergy(jobCost)){
+                    this.memory.gathering = true;
+                    delete this.memory.targetId;
+                }
                 break;
         }
     }
@@ -83,7 +101,7 @@ export class WaveCreep extends Creep {
                 break;
             case ERR_NOT_ENOUGH_RESOURCES:
                 this.memory.gathering = true;
-            case 0:
+            case OK:
             case ERR_FULL:
                 delete this.memory.targetId;
                 break;
@@ -91,12 +109,9 @@ export class WaveCreep extends Creep {
     }
 
     protected runRepairJob(target: Structure) {
-        if (target.hits == target.hitsMax) {
-            delete this.memory.targetId;
-            return;
-        }
-
-        switch (this.repair(target)) {
+        let jobCost = REPAIR_COST * REPAIR_POWER * this.getActiveBodyparts(WORK);
+        let repairSuccess = this.repair(target)
+        switch (repairSuccess) {
             case ERR_NOT_IN_RANGE:
                 this.travelTo(target, { visualizePathStyle: { stroke: '#ffffff' } });
                 break;
@@ -105,6 +120,35 @@ export class WaveCreep extends Creep {
             case ERR_INVALID_TARGET:
                 delete this.memory.targetId;
                 break;
+            case OK:
+                if(this.isRepairFinished(target)) {
+                    delete this.memory.targetId;
+                }
+                if(this.usedAllRemainingEnergy(jobCost)){
+                    this.memory.gathering = true;
+                    delete this.memory.targetId;
+                }
+                break;
         }
+    }
+
+    private isRepairFinished(target: Structure): boolean {
+        let workValue = this.getActiveBodyparts(WORK) * REPAIR_POWER;
+        if (target.hits >= target.hitsMax - workValue) {
+            return true;
+        }
+        return false;
+    }
+
+    private isBuildFinished(target: ConstructionSite): boolean {
+        let workValue = this.getActiveBodyparts(WORK) * BUILD_POWER;
+        if (target.progress >= target.progressTotal - workValue) {
+            return true;
+        }
+        return false;
+    }
+
+    private usedAllRemainingEnergy(energyUsedPerWork: number){
+        return this.store[RESOURCE_ENERGY] <= energyUsedPerWork;
     }
 }

--- a/src/roles/maintainer.ts
+++ b/src/roles/maintainer.ts
@@ -15,7 +15,6 @@ export class Maintainer extends WaveCreep {
             if (target instanceof StructureController) {
                 this.runUpgradeJob();
             } else if (target instanceof Structure) {
-                this.targetProgressCheck(target);
                 this.runRepairJob(target);
             } else if (target instanceof ConstructionSite) {
                 this.runBuildJob(target);
@@ -49,12 +48,6 @@ export class Maintainer extends WaveCreep {
             return constructionSites.sort((a, b) => b.progress / b.progressTotal - a.progress / a.progressTotal).shift().id;
         } else {
             return this.room.controller?.id;
-        }
-    }
-
-    private targetProgressCheck(target: Structure) {
-        if (target instanceof Structure && target.hits === target.hitsMax) {
-            this.memory.targetId = this.findTarget();
         }
     }
 }

--- a/src/roles/maintainer.ts
+++ b/src/roles/maintainer.ts
@@ -38,7 +38,7 @@ export class Maintainer extends WaveCreep {
             let mostDamagedStructures = damagedStructures.filter(
                 (s) => s.hits / s.hitsMax === damagedStructures[0].hits / damagedStructures[0].hitsMax
             );
-            return this.pos.findClosestByPath(mostDamagedStructures).id;
+            return this.pos.findClosestByPath(mostDamagedStructures, {range: 3, ignoreCreeps: true}).id;
         }
 
         let constructionSites = this.room.find(FIND_MY_CONSTRUCTION_SITES);

--- a/src/roles/worker.ts
+++ b/src/roles/worker.ts
@@ -37,12 +37,12 @@ export class Worker extends WaveCreep {
         );
 
         if (spawnStructures.length) {
-            return this.pos.findClosestByPath(spawnStructures).id;
+            return this.pos.findClosestByPath(spawnStructures, {ignoreCreeps: true}).id;
         }
 
         let towers = this.room.find(FIND_MY_STRUCTURES).filter((s) => s.structureType === STRUCTURE_TOWER && s.store[RESOURCE_ENERGY] < 700);
         if (towers.length) {
-            return this.pos.findClosestByPath(towers).id;
+            return this.pos.findClosestByPath(towers, {ignoreCreeps: true}).id;
         }
 
         let constructionSites = this.room.find(FIND_MY_CONSTRUCTION_SITES);


### PR DESCRIPTION
Previously, jobs depended solely upon the return value from the creep method, which leads to lost ticks while the creep realizes that its work is done. Now, they should realize they are done after they work and immediately move on.