### PR TITLE
Melvin sandbox

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -6,7 +6,8 @@ interface CreepMemory {
     room?: string;
     role?: Role;
     currentTaskPriority?: Priority;
-    _move?: TravelData;
+    _move: MoveMemory;
+    _m?: TravelData;
 }
 
 interface Creep {

--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -13,12 +13,20 @@ interface TravelToOpts extends MoveToOpts {
     priority?: Priority;
 }
 
-interface TravelData {
+/**
+ * This is the default memory implemented by screeps
+ */
+interface MoveMemory {
     dest?: Destination;
-    time?: number;
     path?: string;
     room?: string;
-    prevCoords?: Coord;
+}
+
+/**
+ * Custom movement information for the travel function
+ */
+interface TravelData {
+    prevPos?: RoomPosition;
     stuckCount?: number;
 }
 


### PR DESCRIPTION
Fix:

- avoidOnLastMove should now correctly work and no longer cause a creep to avoid all roads along a certain y value
- When stuck a creep should not correctly reset after using the "stuck" path