### PR TITLE
Spawn assignments plus better expansion

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -1,4 +1,5 @@
 interface CreepMemory {
+    destination?: string;
     assignment?: string;
     targetId?: Id<Structure> | Id<ConstructionSite>;
     miningPos?: string;
@@ -6,7 +7,7 @@ interface CreepMemory {
     room?: string;
     role?: Role;
     currentTaskPriority?: Priority;
-    _move: MoveMemory;
+    _move?: MoveMemory;
     _m?: TravelData;
 }
 

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -1,0 +1,27 @@
+interface Memory {
+    empire: EmpireMemory;
+}
+
+interface EmpireMemory {
+    spawnAssignments?: SpawnAssignment[];
+    colonizationOperations?: ColonizationOperation[]; //room names
+}
+
+interface SpawnAssignment {
+    designee: string; //room name
+    memoryOptions: CreepMemory;
+    body: BodyPartConstant[];
+}
+
+interface ColonizationOperation {
+    destination: string; //room name
+    origin: string; //room name
+    stage: ColonizeStage;
+    spawnPosition: string;
+}
+
+const enum ColonizeStage {
+    CLAIM = 'Claim',
+    BUILD = 'Build',
+    COMPLETE = 'Complete',
+}

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -8,6 +8,7 @@ interface RoomMemory {
     availableSourceAccessPoints: string[];
     sourceAccessPointCount: number;
     roadsConstructed?: boolean;
+    spawnAssignments: Role[];
 }
 
 interface Room {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import driveCreep from './modules/creepDriver';
+import { manageEmpire } from './modules/empireManagement';
 import { manageMemory } from './modules/memoryManagement';
 import { populationControl } from './modules/populationManagement';
 import { driveRoom } from './modules/roomManagement';
@@ -6,6 +7,12 @@ import { WaveCreep } from './virtualCreeps/waveCreep';
 require('./prototypes/requirePrototypes');
 
 module.exports.loop = function () {
+    try {
+        manageEmpire();
+    } catch (e) {
+        console.log(`Error caught in empire management: \n${e}`);
+    }
+
     Object.values(Game.rooms)
         .filter((r) => r.controller?.my)
         .forEach((room) => {

--- a/src/modules/empireManagement.ts
+++ b/src/modules/empireManagement.ts
@@ -1,0 +1,95 @@
+import { createPartsArray } from './populationManagement';
+
+export function manageEmpire() {
+    if (!Memory.empire) {
+        Memory.empire = {
+            spawnAssignments: [],
+            colonizationOperations: [],
+        };
+    }
+
+    if (Game.flags.colonize) {
+        addColonizationOperation();
+    }
+
+    if (Memory.empire.colonizationOperations.length) {
+        manageColonistCreeps();
+    }
+}
+
+export function manageColonistCreeps() {
+    Memory.empire.colonizationOperations.forEach((colonizeOp, index) => {
+        switch (colonizeOp.stage) {
+            case ColonizeStage.CLAIM:
+                let claimerExistsOrAssigned: boolean =
+                    Object.values(Memory.creeps).filter((creep) => creep.role === Role.CLAIMER && creep.destination === colonizeOp.destination)
+                        .length +
+                        Memory.empire.spawnAssignments.filter(
+                            (creep) => creep.memoryOptions.destination === colonizeOp.destination && creep.memoryOptions.role === Role.CLAIMER
+                        ).length >
+                    0;
+                if (!claimerExistsOrAssigned) {
+                    Memory.empire.spawnAssignments.push({
+                        designee: colonizeOp.origin,
+                        body: [MOVE, MOVE, MOVE, MOVE, MOVE, CLAIM],
+                        memoryOptions: {
+                            role: Role.CLAIMER,
+                            destination: colonizeOp.destination,
+                        },
+                    });
+                }
+                break;
+            case ColonizeStage.BUILD:
+                let numberOfColonizersFound =
+                    Object.values(Memory.creeps).filter((creep) => creep.role === Role.COLONIZER && creep.destination === colonizeOp.destination)
+                        .length +
+                    Memory.empire.spawnAssignments.filter(
+                        (creep) => creep.memoryOptions.destination === colonizeOp.destination && creep.memoryOptions.role === Role.COLONIZER
+                    ).length;
+                if (numberOfColonizersFound < 2) {
+                    Memory.empire.spawnAssignments.push({
+                        designee: colonizeOp.origin,
+                        body: createPartsArray([WORK, CARRY, MOVE, MOVE], Game.rooms[colonizeOp.origin].energyCapacityAvailable),
+                        memoryOptions: {
+                            role: Role.COLONIZER,
+                            destination: colonizeOp.destination,
+                        },
+                    });
+                }
+                break;
+            case ColonizeStage.COMPLETE:
+                Memory.empire.colonizationOperations.splice(index, 1);
+                break;
+        }
+    });
+}
+
+function addColonizationOperation() {
+    let bestOrigin = findBestColonyOrigin(Game.flags.colonize.pos.roomName);
+
+    if (bestOrigin) {
+        let newOp: ColonizationOperation = {
+            destination: Game.flags.colonize.pos.roomName,
+            origin: bestOrigin,
+            stage: ColonizeStage.CLAIM,
+            spawnPosition: Game.flags.colonize.pos.toMemSafe(),
+        };
+        Memory.empire.colonizationOperations.push(newOp);
+    } else {
+        console.log('No suitable colony origin found');
+    }
+
+    Game.flags.colonize.remove();
+}
+
+function findBestColonyOrigin(targetRoom: string) {
+    let possibleSpawnRooms = Object.values(Game.rooms).filter((room) => room.controller?.my && room.memory.phase === 2);
+
+    let closestRoom = possibleSpawnRooms.reduce((closestRoom, roomToCompare) =>
+        Game.map.getRoomLinearDistance(closestRoom.name, targetRoom) < Game.map.getRoomLinearDistance(roomToCompare.name, targetRoom)
+            ? closestRoom
+            : roomToCompare
+    );
+
+    return Game.map.getRoomLinearDistance(closestRoom.name, targetRoom) < 11 ? closestRoom.name : undefined;
+}

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -17,10 +17,10 @@ function handleDeadCreep(creepName: string) {
     let deadCreepMemory = Memory.creeps[creepName];
 
     if (deadCreepMemory.miningPos) {
-        Game.rooms[deadCreepMemory.room].memory.availableSourceAccessPoints.push(deadCreepMemory.miningPos);
+        Memory.rooms[deadCreepMemory.room || deadCreepMemory.destination].availableSourceAccessPoints.push(deadCreepMemory.miningPos);
     }
-    if (deadCreepMemory.assignment) {
-        Game.rooms[deadCreepMemory.room].memory.miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
+    if (deadCreepMemory.role === Role.MINER) {
+        Memory.rooms[deadCreepMemory.room].miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
     }
 
     delete Memory.creeps[creepName];

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -53,6 +53,8 @@ function phaseOneSpawning(spawn: StructureSpawn) {
 
     if (roomCreeps.filter((creep) => creep.memory.role === Role.WORKER).length < WORKER_LIMIT) {
         options.memory.role = Role.WORKER;
+    } else if (checkForSpawnAssignments(spawn.room)) {
+        spawnAssignedCreep(spawn);
     } else if (roomCreeps.filter((creep) => creep.memory.role === Role.UPGRADER).length < UPGRADER_LIMIT) {
         options.memory.role = Role.UPGRADER;
     } else if (roomCreeps.filter((creep) => creep.memory.role === Role.MAINTAINTER).length < MAINTAINTER_LIMIT) {
@@ -99,7 +101,6 @@ function phaseTwoSpawning(spawn: StructureSpawn) {
     const UPGRADER_LIMIT = WORKER_SPAWN_LIMIT / 2;
     const MAINTAINTER_LIMIT = WORKER_SPAWN_LIMIT / 2;
     const BUILDER_LIMIT = Math.ceil(WORKER_SPAWN_LIMIT / 4);
-    const COLONIZER_LIMIT = 2;
 
     let roomCreeps = Object.values(Game.creeps).filter((creep) => creep.memory.room === spawn.room.name);
 
@@ -115,7 +116,6 @@ function phaseTwoSpawning(spawn: StructureSpawn) {
 
     let partBlockToUse: BodyPartConstant[];
     let partsArray = [];
-    let specialSpawnCase = false;
     let sizeLimitDivisor = 1;
 
     if (roomCreeps.filter((creep) => creep.memory.role === Role.DISTRIBUTOR).length === 0) {
@@ -123,10 +123,11 @@ function phaseTwoSpawning(spawn: StructureSpawn) {
         partBlockToUse = TRANSPORT_PART_BLOCK;
     } else if (needMiner(spawn.room)) {
         spawnMiner(spawn);
-        specialSpawnCase = true;
     } else if (roomCreeps.filter((creep) => creep.memory.role === Role.TRANSPORTER).length === 0) {
         options.memory.role = Role.TRANSPORTER;
         partBlockToUse = TRANSPORT_PART_BLOCK;
+    } else if (checkForSpawnAssignments(spawn.room)) {
+        spawnAssignedCreep(spawn);
     } else if (roomCreeps.filter((creep) => creep.memory.role === Role.UPGRADER).length < UPGRADER_LIMIT) {
         options.memory.role = Role.UPGRADER;
         partBlockToUse = WORKER_PART_BLOCK;
@@ -140,15 +141,9 @@ function phaseTwoSpawning(spawn: StructureSpawn) {
     ) {
         options.memory.role = Role.BUILDER;
         partBlockToUse = WORKER_PART_BLOCK;
-    } else if (Game.flags.claimer && !Object.values(Game.creeps).filter((creep) => creep.memory.role === Role.CLAIMER).length) {
-        options.memory.role = Role.CLAIMER;
-        partsArray = [MOVE, MOVE, MOVE, MOVE, MOVE, CLAIM];
-    } else if (Game.flags.colonizer && Object.values(Game.creeps).filter((creep) => creep.memory.role === Role.COLONIZER).length < COLONIZER_LIMIT) {
-        options.memory.role = Role.COLONIZER;
-        partBlockToUse = WORKER_PART_BLOCK;
     }
 
-    if (!specialSpawnCase) {
+    if (options.memory.role) {
         if (partBlockToUse) {
             partsArray = createPartsArray(partBlockToUse, spawn.room.energyCapacityAvailable, sizeLimitDivisor);
         }
@@ -232,7 +227,7 @@ function spawnMiner(spawn: StructureSpawn) {
     }
 }
 
-function createPartsArray(partsBlock: BodyPartConstant[], energyCapacityAvailable: number, sizeLimitDivisor: number): BodyPartConstant[] {
+export function createPartsArray(partsBlock: BodyPartConstant[], energyCapacityAvailable: number, sizeLimitDivisor: number = 1): BodyPartConstant[] {
     let partsBlockCost = partsBlock.map((part) => BODYPART_COST[part]).reduce((sum, partCost) => sum + partCost);
     let partsArray = [];
 
@@ -241,4 +236,24 @@ function createPartsArray(partsBlock: BodyPartConstant[], energyCapacityAvailabl
     }
 
     return partsArray;
+}
+
+function checkForSpawnAssignments(room: Room) {
+    return Memory.empire.spawnAssignments.find((assignment) => assignment.designee === room.name);
+}
+
+function spawnAssignedCreep(spawn: StructureSpawn) {
+    const ASSIGNMENT_INDEX = Memory.empire.spawnAssignments.findIndex((assignment) => assignment.designee === spawn.room.name);
+    let assignment = Memory.empire.spawnAssignments[ASSIGNMENT_INDEX];
+    let options: SpawnOptions = {
+        memory: {
+            _move: {},
+            ...assignment.memoryOptions,
+        },
+    };
+
+    let result = spawn.spawnCreep(assignment.body, `${options.memory.role} ${Game.time}`, options);
+    if (result === OK) {
+        Memory.empire.spawnAssignments.splice(ASSIGNMENT_INDEX, 1);
+    }
 }

--- a/src/roles/claimer.ts
+++ b/src/roles/claimer.ts
@@ -2,23 +2,23 @@ import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class Claimer extends WaveCreep {
     public run() {
-        const flag = Game.flags.claimer;
+        let destination = Game.rooms[this.memory.destination];
 
-        if (flag) {
-            // Go to the target room
-            if (this.travelToRoom(flag.pos.roomName) === IN_ROOM) {
-                // Claim Controller in target room
-                switch (this.claimController(this.room.controller)) {
-                    case ERR_NOT_IN_RANGE:
-                        this.travelTo(this.room.controller, { range: 1, swampCost: 1 });
-                        break;
-                    case OK:
-                        Game.flags.claimer.remove();
-                        flag.room.createFlag(flag.pos, 'colonizer'); // Send colonizer
-                        console.log(`${this.room.name} has been claimed!`);
-                        this.suicide();
-                        break;
-                }
+        // Go to the target room
+        if (this.travelToRoom(this.memory.destination) === IN_ROOM) {
+            // Claim Controller in target room
+            switch (this.claimController(this.room.controller)) {
+                case ERR_NOT_IN_RANGE:
+                    this.travelTo(this.room.controller, { range: 1, swampCost: 1 });
+                    break;
+                case ERR_INVALID_TARGET:
+                case OK:
+                    console.log(`${this.room.name} has been claimed!`);
+
+                    let opIndex = Memory.empire.colonizationOperations.findIndex((op) => op.destination === this.room.name);
+                    Memory.empire.colonizationOperations[opIndex].stage = ColonizeStage.BUILD;
+                    this.suicide();
+                    break;
             }
         }
     }

--- a/src/roles/colonizer.ts
+++ b/src/roles/colonizer.ts
@@ -1,36 +1,47 @@
+import { posFromMem } from '../modules/memoryManagement';
 import { EarlyCreep } from '../virtualCreeps/earlyCreep';
 
 export class Colonizer extends EarlyCreep {
     protected performDuties() {
-        const flag = Game.flags.colonizer;
+        // Go to the target room
+        if (this.travelToRoom(this.memory.destination) === IN_ROOM) {
+            let target = Game.getObjectById(this.memory.targetId);
 
-        if (flag) {
-            // Go to the target room
-            if (this.travelToRoom(flag.pos.roomName) === IN_ROOM) {
-                let target = Game.getObjectById(this.memory.targetId);
+            if (!this.memory.targetId || !target) {
+                this.memory.targetId = this.findTarget();
+                target = Game.getObjectById(this.memory.targetId);
+            }
+            if (target instanceof ConstructionSite) {
+                // Create Spawn in target room
+                this.runBuildJob(target);
+            } else if (target instanceof StructureSpawn) {
+                console.log(`${this.room.name} spawn has been build!`);
 
-                if (!this.memory.targetId || !target) {
-                    this.memory.targetId = this.findTarget();
-                    target = Game.getObjectById(this.memory.targetId);
+                let opIndex = Memory.empire.colonizationOperations.findIndex((op) => op.destination === this.room.name);
+                if (Memory.empire.colonizationOperations[opIndex]) {
+                    Memory.empire.colonizationOperations[opIndex].stage = ColonizeStage.COMPLETE;
                 }
-                if (target instanceof ConstructionSite) {
-                    // Create Spawn in target room
-                    this.runBuildJob(target);
-                } else {
-                    // finished building spawn
-                    Game.flags.colonizer.remove();
-                    console.log(`${this.room.name} spawn has been build!`);
-                    this.memory.role = Role.WORKER; // Turn into worker
-                    this.memory.room = this.room.name; // Change to new room
-                }
+                this.memory.role = Role.WORKER; // Turn into worker
+                this.memory.room = this.room.name; // Change to new room
+            } else {
+                let opIndex = Memory.empire.colonizationOperations.findIndex((op) => op.destination === this.room.name);
+                let spawnPos = posFromMem(Memory.empire.colonizationOperations[opIndex].spawnPosition);
+                this.room.createConstructionSite(spawnPos.x, spawnPos.y, STRUCTURE_SPAWN);
             }
         }
     }
 
-    private findTarget(): Id<ConstructionSite> {
-        return this.room
-            .find(FIND_MY_CONSTRUCTION_SITES) //
-            .filter((constructionSite) => constructionSite.structureType === STRUCTURE_SPAWN) //
-            .map((spawnConstructionSite) => spawnConstructionSite.id)[0];
+    private findTarget(): Id<ConstructionSite> | Id<Structure> {
+        let opIndex = Memory.empire.colonizationOperations.findIndex((op) => op.destination === this.room.name);
+        let spawnPos = posFromMem(Memory.empire.colonizationOperations[opIndex].spawnPosition);
+
+        let lookResults = spawnPos.look();
+        if (lookResults.filter((object) => object.type === LOOK_CONSTRUCTION_SITES).length) {
+            return lookResults.filter((object) => object.type === LOOK_CONSTRUCTION_SITES).shift().constructionSite.id;
+        } else if (lookResults.filter((object) => object.type === LOOK_STRUCTURES).length) {
+            return lookResults.filter((object) => object.type === LOOK_STRUCTURES).shift().structure.id;
+        }
+
+        return undefined;
     }
 }

--- a/src/virtualCreeps/workerCreep.ts
+++ b/src/virtualCreeps/workerCreep.ts
@@ -106,6 +106,9 @@ export class WorkerCreep extends WaveCreep {
                     delete this.memory.targetId;
                 }
                 break;
+            case ERR_INVALID_TARGET:
+                delete this.memory.targetId;
+                break;
         }
     }
 


### PR DESCRIPTION
# Additions
This PR adds two features:

1. Empire memory storage w/ an empire-wide spawn queue, and
2. Improvements to colony expansion code using empire memory

## Spawn queue
Memory.empire,spawnAssignments is an array of SpawnAssignments, which consist of a designated room, a body, and memory options for the required creep. Rooms will now check Memory.empire.spawnAssignments for creeps they have been assigned to spawn. 

## Expansion improvements
To expand, place a "colonize" flag **at the desired location of a spawn point** in your target room. The script stores the flag's position, removes the flag, and selects the closest room **in Phase Two** as the spawn point for colonist creeps. From there, the creeps will move to the room, place the spawn construction point, and build the spawn.