### PR TITLE
Add collection queue

### DIFF
--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -1,4 +1,6 @@
 interface RoomMemory {
+    collectSearchCooldown: number;
+    collectQueue: (Id<Structure> | Id<Resource> | Id<Tombstone> | Id<Ruin>)[];
     repairSearchCooldown: number;
     repairQueue: Id<Structure<StructureConstant>>[];
     miningAssignments: Map<string, AssignmentStatus>;
@@ -13,6 +15,7 @@ interface RoomMemory {
 
 interface Room {
     getRepairTarget(): Id<Structure>;
+    getCollectionTarget(): Id<Structure> | Id<Resource> | Id<Tombstone> | Id<Ruin>;
 }
 
 interface RoomPosition {

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -1,4 +1,4 @@
-import { findRepairTargets } from '../modules/roomManagement';
+import { findCollectionTargets, findRepairTargets } from '../modules/roomManagement';
 
 RoomPosition.prototype.toMemSafe = function (this: RoomPosition): string {
     return `${this.x}.${this.y}.${this.roomName}`;
@@ -13,4 +13,14 @@ Room.prototype.getRepairTarget = function (this: Room): Id<Structure> {
     }
 
     return this.memory.repairQueue.shift();
+};
+
+Room.prototype.getCollectionTarget = function (this: Room): Id<Structure> | Id<Resource> | Id<Tombstone> | Id<Ruin> {
+    let targets = this.memory.collectQueue;
+
+    if (targets.length === 0) {
+        this.memory.collectQueue = findCollectionTargets(this);
+    }
+
+    return this.memory.collectQueue.shift();
 };


### PR DESCRIPTION
This PR would add a collection queue to prevent Transporters and Distributors from going after the same target to collect.

This _doesn't_ seem like the best solution in all cases, however. For example, an exception for ruins needs to be added so ruins can be collected from until appropriate. Structures that hold more than a creep can carry will not get fully emptied before a new target is selected. Needs work.