### PR TITLE
Added protector unit

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -1,7 +1,7 @@
 interface CreepMemory {
     destination?: string;
     assignment?: string;
-    targetId?: Id<Structure> | Id<ConstructionSite>;
+    targetId?: Id<Structure> | Id<ConstructionSite> | Id<Creep>;
     miningPos?: string;
     gathering?: boolean;
     room?: string;
@@ -42,4 +42,5 @@ const enum Role {
     CLAIMER = 'CLAIMER',
     COLONIZER = 'COLONIZER',
     BUILDER = 'BUILDER',
+    PROTECTOR = 'PROTECTOR',
 }

--- a/src/modules/creepDriver.ts
+++ b/src/modules/creepDriver.ts
@@ -11,6 +11,7 @@ import { Claimer } from '../roles/claimer';
 import { Colonizer } from '../roles/colonizer';
 import { Builder } from '../roles/builder';
 import { EarlyBuilder } from '../roles/earlyBuilder';
+import { Protector } from '../roles/protector';
 
 export default function driveCreep(creep: Creep) {
     let waveCreep: WaveCreep;
@@ -54,6 +55,9 @@ export default function driveCreep(creep: Creep) {
             break;
         case Role.COLONIZER:
             waveCreep = new Colonizer(creep.id);
+            break;
+        case Role.PROTECTOR:
+            waveCreep = new Protector(creep.id);
             break;
         default:
             waveCreep = new WaveCreep(creep.id);

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -1,4 +1,5 @@
 import { posFromMem } from './memoryManagement';
+import { createPartsArray } from './populationManagement';
 
 export function driveRoom(room: Room) {
     if (room.memory?.phase == undefined) {
@@ -15,6 +16,7 @@ export function driveRoom(room: Room) {
     }
 
     runTowers(room);
+    runHomeSecurity(room);
 }
 
 function runTowers(room: Room) {
@@ -28,6 +30,25 @@ function runTowers(room: Room) {
     healers.length
         ? towers.forEach((tower) => tower.attack(tower.pos.findClosestByRange(healers)))
         : towers.forEach((tower) => tower.attack(tower.pos.findClosestByRange(hostileCreeps)));
+}
+
+function runHomeSecurity(room: Room) {
+    const hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
+
+    // can be optimized to spawn more protectors if more enemies are in room. In that case, add a "wait" function in the protector to wait for all protectors to spawn before attacking
+    if (
+        hostileCreeps.length > 1 &&
+        !Object.values(Memory.creeps).filter((creep) => creep.role === Role.PROTECTOR).length &&
+        !Memory.empire.spawnAssignments.filter((creep) => creep.memoryOptions.role === Role.PROTECTOR).length
+    ) {
+        Memory.empire.spawnAssignments.push({
+            designee: room.name,
+            body: createPartsArray([ATTACK, MOVE], room.energyCapacityAvailable),
+            memoryOptions: {
+                role: Role.PROTECTOR,
+            },
+        });
+    }
 }
 
 function initRoomMemory(room: Room) {

--- a/src/roles/protector.ts
+++ b/src/roles/protector.ts
@@ -1,0 +1,37 @@
+import { WaveCreep } from '../virtualCreeps/waveCreep';
+
+export class Protector extends WaveCreep {
+    public run() {
+        if (!this.memory.targetId) {
+            this.memory.targetId = this.findTarget();
+        }
+        this.attackCreep();
+    }
+
+    private findTarget() {
+        const hostileCreeps = this.room.find(FIND_HOSTILE_CREEPS);
+        if (hostileCreeps.length) {
+            const healers = hostileCreeps.filter((creep) => creep.getActiveBodyparts(HEAL) > 0);
+
+            return healers.length ? this.pos.findClosestByRange(healers).id : this.pos.findClosestByRange(hostileCreeps).id;
+        }
+    }
+
+    private attackCreep() {
+        const target = Game.getObjectById(this.memory.targetId);
+        if (target instanceof Creep) {
+            const result = this.getActiveBodyparts(ATTACK) ? this.attack(target) : this.rangedAttack(target);
+
+            switch (result) {
+                case ERR_NOT_IN_RANGE:
+                    this.travelTo(target, { ignoreCreeps: false, reusePath: 0, visualizePathStyle: { stroke: '#ffffff' } });
+                    break;
+                case OK:
+                    break;
+                default: // aquire new target
+                    this.memory.targetId = this.findTarget();
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Should spawn protector units if attacked by more than one unit. Even with invaders I noticed that if there are two where one is a healer, then 2 towers are not enough to kill it. With a ranged_attack unit it is still not enough but a melee unit will do just fine. Since it is in the home base he usually also has no problem getting close to the target due to ramparts/walls. 

In the new function (runHomeSecurity), we can later expand it with the safeMode if we notice we are fighting a loosing battle (maybe see if there are ruins which means the walls/ramparts didn't hold or simply check enemy quanitity + body parts). This at least seems better than nothing.