### PR TITLE
Avoid Hostile attack creeps

### DIFF
--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -11,6 +11,10 @@ interface TravelToOpts extends MoveToOpts {
      * Set task priority.
      */
     priority?: Priority;
+    /**
+     * Default it is set to false to minimize cpu cost as most creeps are traveling inside the base.
+     */
+    avoidHostiles?: boolean;
 }
 
 /**

--- a/src/prototypes/creep.ts
+++ b/src/prototypes/creep.ts
@@ -9,7 +9,7 @@ Creep.prototype.travelToRoom = function (roomName, opts) {
     if (this.room.name === roomName && !this.onEdge()) {
         return IN_ROOM;
     }
-    return this.travelTo(new RoomPosition(25, 25, roomName), { ...opts, range: 23, reusePath: 50, maxOps: 10000 });
+    return this.travelTo(new RoomPosition(25, 25, roomName), { ...opts, range: 23, reusePath: 50, avoidHostiles: true, maxOps: 10000 });
 };
 
 Creep.prototype.onEdge = function () {


### PR DESCRIPTION
Has only been tested in one case so not sure it works perfectly yet. 
The "travelToRoom" function automatically uses this feature if not otherwise specified. For the normal "travelTo" it has to be specifically set as most creeps wont need it (only run inside the base so don't want to waste cpu on this).

Limitations: So far only creeps with attack bodies are being avoided (range of 3 tiles around the creep). This is done once per room (or if path needs to be recalculated). So if a hostileCreep moves the matrix is not updated.