### PR TITLE
Remove traps from room memory and track gates independently

### DIFF
--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -1,4 +1,5 @@
 interface RoomMemory {
+    gates: Gate[];
     traps: CreepTrap[];
     repairSearchCooldown: number;
     repairQueue: Id<Structure<StructureConstant>>[];
@@ -40,10 +41,10 @@ const enum EnergyStatus {
 }
 
 interface CreepTrap {
-    gates: TrapGate[];
+    gates: Gate[];
 }
 
-interface TrapGate {
+interface Gate {
     id: Id<StructureRampart>;
     lastToggled: number;
 }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -19,7 +19,15 @@ export function driveRoom(room: Room) {
     runHomeSecurity(room);
 
     if (room.memory.traps?.length) {
-        room.memory.traps.forEach((trap) => runTrap(trap));
+        room.memory.gates = [];
+        room.memory.traps.forEach((trap) => {
+            room.memory.gates.push(...trap.gates);
+        });
+        delete room.memory.traps;
+    }
+
+    if (room.memory.gates?.length) {
+        runGates(room);
     }
 }
 
@@ -73,6 +81,7 @@ function initRoomMemory(room: Room) {
 
     room.memory.sourceAccessPointCount = room.memory.availableSourceAccessPoints.length;
     room.memory.phase = 1;
+    room.memory.gates = [];
 }
 
 function runPhaseOne(room: Room) {
@@ -235,8 +244,8 @@ export function findRepairTargets(room: Room): Id<Structure>[] {
     return repairTargetQueue;
 }
 
-function runTrap(trap: CreepTrap): void {
-    let gates = trap.gates.filter((gate) => Game.getObjectById(gate.id));
+function runGates(room: Room): void {
+    let gates = room.memory.gates.filter((gate) => Game.getObjectById(gate.id));
 
     gates.forEach((gateId) => {
         if (gateId.lastToggled === undefined) {
@@ -254,5 +263,5 @@ function runTrap(trap: CreepTrap): void {
         }
     });
 
-    trap.gates = gates;
+    room.memory.gates = gates;
 }


### PR DESCRIPTION
This will convert room using the old Trap memory structure into the correct form. It will NOT add a Gates array to preexisting rooms WITHOUT traps in memory.