### PR TITLE
Melvin sandbox

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -63,6 +63,7 @@ const enum Role {
     BUILDER = 'BUILDER',
     SCOUT = 'SCOUT',
     PROTECTOR = 'PROTECTOR',
+    RAMPART_PROTECTOR = 'RAMPART_PROTECTOR',
     GO = 'GO',
     RESERVER = 'RESERVER',
     MANAGER = 'MANAGER',

--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -5,6 +5,7 @@ interface CreepMemory {
     assignment?: string;
     targetId?: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone>;
     miningPos?: string;
+    hasTTLReplacement?: boolean;
     gathering?: boolean;
     energySource?: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin>;
     room?: string;

--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -51,6 +51,10 @@ interface TravelToOpts extends PathFinderOpts {
      * For adding costs to the matrix.
      */
     customMatrixCosts?: CustomMatrixCost[];
+    /**
+     * Prefer moving over ramparts. It will set the efficiency of creeps lower so they will avoid walking over plain.
+     */
+    preferRamparts?: boolean;
 }
 
 interface CustomMatrixCost {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -25,6 +25,7 @@ interface RemoteAssignment {
 
 interface Room {
     removeFromRepairQueue(id: string): void;
+    creeps: Creep[];
     energyStatus: EnergyStatus;
     mineral: Mineral;
     managerLink: StructureLink;

--- a/src/modules/creepDriver.ts
+++ b/src/modules/creepDriver.ts
@@ -13,6 +13,7 @@ import { RemoteMiner } from '../roles/remoteMiner';
 import { Manager } from '../roles/manager';
 import { Operative } from '../roles/operative';
 import { Colonizer } from '../roles/colonizer';
+import { RampartProtector } from '../roles/rampartProtector';
 
 export default function driveCreep(creep: Creep) {
     let waveCreep: WaveCreep;
@@ -63,6 +64,9 @@ export default function driveCreep(creep: Creep) {
             break;
         case Role.OPERATIVE:
             waveCreep = new Operative(creep.id);
+            break;
+        case Role.RAMPART_PROTECTOR:
+            waveCreep = new RampartProtector(creep.id);
             break;
         default:
             waveCreep = new WaveCreep(creep.id);

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -19,7 +19,7 @@ function handleDeadCreep(creepName: string) {
     let deadCreepMemory = Memory.creeps[creepName];
 
     if (Game.rooms[deadCreepMemory.room]?.controller?.my) {
-        if (deadCreepMemory.role === Role.MINER) {
+        if (deadCreepMemory.role === Role.MINER && !deadCreepMemory.hasTTLReplacement) {
             Memory.rooms[deadCreepMemory.room].miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
         if (

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -279,7 +279,7 @@ export class Pathing {
         origin = Pathing.normalizePos(origin);
         destination = Pathing.normalizePos(destination);
         const range = Pathing.ensureRangeIsInRoom(origin.roomName, destination, options.range);
-        if (options.preferRoadConstruction) {
+        if (options.preferRoadConstruction || options.preferRamparts) {
             efficiency = 0.8; // Make other tiles cost more to avoid multiple roads
         }
         return PathFinder.search(
@@ -386,6 +386,13 @@ export class Pathing {
                     room.find(FIND_MY_CONSTRUCTION_SITES, { filter: (struct) => struct.structureType === STRUCTURE_ROAD }).forEach((struct) =>
                         matrix.set(struct.pos.x, struct.pos.y, 1)
                     );
+                }
+
+                if (options.preferRamparts) {
+                    matrix = matrix.clone();
+                    room.find(FIND_MY_STRUCTURES, { filter: (struct) => struct.structureType === STRUCTURE_RAMPART }).forEach((rampart) => {
+                        matrix.set(rampart.pos.x, rampart.pos.y, 1);
+                    });
                 }
 
                 if (options.customMatrixCosts) {

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -111,6 +111,7 @@ export class Pathing {
                 creep.memory._m.repath++;
                 opts.pathColor = 'blue';
                 opts.ignoreCreeps = false;
+                opts.preferRamparts = false;
                 delete creep.memory._m.path; // recalculate path (for now this will be used all the way till the target...could implement a recalculate after n ticks method to go back to original path after getting unstuck)
             } else {
                 new RoomVisual(creep.pos.roomName).circle(creep.pos, {

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -336,7 +336,7 @@ export class Pathing {
                     if (room.find(FIND_STRUCTURES).some((struct) => struct.structureType === STRUCTURE_KEEPER_LAIR)) {
                         room.find(FIND_HOSTILE_CREEPS, {
                             filter: (creep) =>
-                                creep.owner.username === 'Invader' &&
+                                creep.owner.username === 'Source Keeper' &&
                                 (creep.getActiveBodyparts(ATTACK) > 0 || creep.getActiveBodyparts(RANGED_ATTACK) > 0),
                         }).forEach((creep) => {
                             const avoidArea = Pathing.getArea(creep.pos, 3);

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -516,27 +516,19 @@ export class PopulationManagement {
     static needsProtector(roomName: string): boolean {
         return (
             !Object.values(Game.creeps).filter(
-                (creep) =>
-                    creep.memory.role === Role.PROTECTOR &&
-                    !creep.getActiveBodyparts(ATTACK) &&
-                    (creep.memory.assignment === roomName || creep.pos.roomName === roomName)
+                (creep) => creep.memory.role === Role.PROTECTOR && (creep.memory.assignment === roomName || creep.pos.roomName === roomName)
             ).length &&
             !Memory.empire.spawnAssignments.filter(
-                (creep) => creep.memoryOptions.role === Role.PROTECTOR && !creep.body.includes(ATTACK) && creep.memoryOptions.assignment === roomName
+                (creep) => creep.memoryOptions.role === Role.PROTECTOR && creep.memoryOptions.assignment === roomName
             ).length
         );
     }
 
-    static needsMeleeProtector(roomName: string): boolean {
+    static currentNumRampartProtectors(roomName: string): number {
         return (
-            !Object.values(Game.creeps).filter(
-                (creep) =>
-                    creep.memory.role === Role.PROTECTOR &&
-                    creep.getActiveBodyparts(ATTACK) &&
-                    (creep.memory.assignment === roomName || creep.pos.roomName === roomName)
-            ).length &&
-            !Memory.empire.spawnAssignments.filter(
-                (creep) => creep.memoryOptions.role === Role.PROTECTOR && creep.body.includes(ATTACK) && creep.memoryOptions.assignment === roomName
+            Object.values(Game.creeps).filter((creep) => creep.memory.role === Role.RAMPART_PROTECTOR && creep.pos.roomName === roomName).length +
+            Memory.empire.spawnAssignments.filter(
+                (creep) => creep.memoryOptions.role === Role.RAMPART_PROTECTOR && creep.memoryOptions.room === roomName
             ).length
         );
     }

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -100,13 +100,57 @@ export class PopulationManagement {
 
     static needsMiner(room: Room): boolean {
         let roomNeedsMiner = Object.values(room.memory.miningAssignments).some((assignment) => assignment === AssignmentStatus.UNASSIGNED);
-
+        if (!roomNeedsMiner) {
+            // Check for TTL
+            roomNeedsMiner = room.creeps.some(
+                (creep) =>
+                    creep.memory.role === Role.MINER &&
+                    creep.memory.room === room.name &&
+                    !creep.memory.hasTTLReplacement &&
+                    creep.ticksToLive <
+                        PopulationManagement.getMinerBody(posFromMem(creep.memory.assignment), room.energyCapacityAvailable).length * 3
+            );
+        }
         return roomNeedsMiner;
+    }
+
+    static getMinerBody(miningPos: RoomPosition, energyCapacityAvailable: number): (WORK | MOVE | CARRY)[] {
+        let minerBody: (WORK | MOVE | CARRY)[];
+
+        if (energyCapacityAvailable >= 650) {
+            minerBody = [WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE];
+        } else if (energyCapacityAvailable >= 550) {
+            minerBody = [WORK, WORK, WORK, WORK, WORK, MOVE];
+        } else if (energyCapacityAvailable >= 450) {
+            minerBody = [WORK, WORK, WORK, WORK, MOVE];
+        } else if (energyCapacityAvailable >= 350) {
+            minerBody = [WORK, WORK, WORK, MOVE];
+        } else {
+            minerBody = [WORK, WORK, MOVE];
+        }
+
+        let link = miningPos.findInRange(FIND_MY_STRUCTURES, 1).find((s) => s.structureType === STRUCTURE_LINK);
+        if (link) {
+            minerBody.unshift(CARRY);
+        }
+        return minerBody;
     }
 
     static spawnMiner(spawn: StructureSpawn): ScreepsReturnCode {
         let assigmentKeys = Object.keys(spawn.room.memory.miningAssignments);
         let assigment = assigmentKeys.find((pos) => spawn.room.memory.miningAssignments[pos] === AssignmentStatus.UNASSIGNED);
+        let currentMiner: Creep;
+        if (!assigment) {
+            // Check for TTL
+            currentMiner = spawn.room.creeps.find(
+                (creep) =>
+                    creep.memory.role === Role.MINER &&
+                    creep.memory.room === spawn.room.name &&
+                    creep.ticksToLive <
+                        PopulationManagement.getMinerBody(posFromMem(creep.memory.assignment), spawn.room.energyCapacityAvailable).length * 3
+            );
+            assigment = currentMiner?.pos?.toMemSafe();
+        }
 
         let options: SpawnOptions = {
             memory: {
@@ -117,30 +161,22 @@ export class PopulationManagement {
         };
 
         let tag = 'm';
-        let minerBody: ('work' | 'move' | 'carry')[];
-
-        if (spawn.room.energyCapacityAvailable >= 650) {
-            minerBody = [WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE];
-        } else if (spawn.room.energyCapacityAvailable >= 550) {
-            minerBody = [WORK, WORK, WORK, WORK, WORK, MOVE];
-        } else if (spawn.room.energyCapacityAvailable >= 450) {
-            minerBody = [WORK, WORK, WORK, WORK, MOVE];
-        } else if (spawn.room.energyCapacityAvailable >= 350) {
-            minerBody = [WORK, WORK, WORK, MOVE];
-        } else {
-            minerBody = [WORK, WORK, MOVE];
-        }
 
         let assigmentPos = posFromMem(assigment);
-        let link = assigmentPos.findInRange(FIND_MY_STRUCTURES, 1).find((s) => s.structureType === STRUCTURE_LINK);
+        let link = assigmentPos.findInRange(FIND_MY_STRUCTURES, 1).find((s) => s.structureType === STRUCTURE_LINK) as StructureLink;
         if (link) {
-            //@ts-expect-error
             options.memory.link = link.id;
-            minerBody.unshift(CARRY);
         }
 
-        let result = spawn.smartSpawn(minerBody, this.getCreepTag(tag, spawn.name), options);
+        let result = spawn.smartSpawn(
+            PopulationManagement.getMinerBody(assigmentPos, spawn.room.energyCapacityAvailable),
+            this.getCreepTag(tag, spawn.name),
+            options
+        );
         if (result === OK) {
+            if (currentMiner) {
+                currentMiner.memory.hasTTLReplacement = true;
+            }
             spawn.room.memory.miningAssignments[assigment] = AssignmentStatus.ASSIGNED;
         } else if (
             result === ERR_NOT_ENOUGH_ENERGY &&
@@ -150,6 +186,9 @@ export class PopulationManagement {
             let emergencyMinerBody = [WORK, WORK, MOVE];
             result = spawn.smartSpawn(emergencyMinerBody, this.getCreepTag(tag, spawn.name), options);
             if (result === OK) {
+                if (currentMiner) {
+                    currentMiner.memory.hasTTLReplacement = true;
+                }
                 spawn.room.memory.miningAssignments[assigment] = AssignmentStatus.ASSIGNED;
             }
         }

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -516,10 +516,13 @@ export class PopulationManagement {
     static needsProtector(roomName: string): boolean {
         return (
             !Object.values(Game.creeps).filter(
-                (creep) => creep.memory.role === Role.PROTECTOR && (creep.memory.assignment === roomName || creep.pos.roomName === roomName)
+                (creep) =>
+                    creep.memory.role === Role.PROTECTOR &&
+                    !creep.getActiveBodyparts(ATTACK) &&
+                    (creep.memory.assignment === roomName || creep.pos.roomName === roomName)
             ).length &&
             !Memory.empire.spawnAssignments.filter(
-                (creep) => creep.memoryOptions.role === Role.PROTECTOR && creep.memoryOptions.assignment === roomName
+                (creep) => creep.memoryOptions.role === Role.PROTECTOR && !creep.body.includes(ATTACK) && creep.memoryOptions.assignment === roomName
             ).length
         );
     }

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -125,6 +125,12 @@ function reassignIdleProtector(homeRoomName: string, targetRoomName: string): bo
         (creep) => creep.memory.room === homeRoomName && creep.memory.role === Role.PROTECTOR && creep.ticksToLive > 200
     );
 
+    if (homeRoomName === targetRoomName) {
+        // Home Protection (reassign and still spawn default ones)
+        protectors.forEach((protector) => (protector.memory.assignment = targetRoomName));
+        return false;
+    }
+
     const idleProtector = protectors.find(
         (creep) => Memory.rooms[homeRoomName].remoteAssignments?.[creep.memory.assignment]?.state !== RemoteMiningRoomState.SAFE
     );

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -114,6 +114,13 @@ function runTowers(room: Room) {
     // @ts-ignore
     let towers: StructureTower[] = room.find(FIND_STRUCTURES).filter((structure) => structure.structureType === STRUCTURE_TOWER);
 
+    // Heal creeps in baseroom. Can be optimized to check how many towers need to heal one creep but usually this should not be needed anyway if our "room under attack" logic works properly.
+    let myHurtCreep = room.find(FIND_MY_CREEPS).find((creep) => creep.hits < creep.hitsMax);
+    if (myHurtCreep) {
+        towers.forEach((tower) => tower.heal(myHurtCreep));
+        return;
+    }
+
     let hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
 
     let healers = hostileCreeps.filter((creep) => creep.getActiveBodyparts(HEAL) > 0);

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -128,32 +128,44 @@ function runHomeSecurity(homeRoom: Room): boolean {
     let minNumHostileCreeps = homeRoom.controller.level < 4 ? 1 : 2;
 
     if (hostileCreeps.length >= minNumHostileCreeps) {
-        if (PopulationManagement.needsProtector(homeRoom.name)) {
-            const body = PopulationManagement.createPartsArray([RANGED_ATTACK, MOVE], homeRoom.energyCapacityAvailable - 300, 24);
-            body.push(MOVE, HEAL);
+        // Spawn multiple rampartProtectors based on the number of enemy hostiles
+        const currentNumProtectors = PopulationManagement.currentNumRampartProtectors(homeRoom.name);
+        if (!currentNumProtectors) {
+            const body = PopulationManagement.createPartsArray([RANGED_ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
             Memory.empire.spawnAssignments.push({
                 designee: homeRoom.name,
                 body: body,
                 memoryOptions: {
-                    role: Role.PROTECTOR,
+                    role: Role.RAMPART_PROTECTOR,
                     room: homeRoom.name,
-                    assignment: homeRoom.name,
                     currentTaskPriority: Priority.MEDIUM,
                     combat: { flee: false },
                 },
             });
-        } else if (hostileCreeps.length >= 4 && PopulationManagement.needsMeleeProtector(homeRoom.name)) {
+        }
+        if (hostileCreeps.length >= 4 && currentNumProtectors - Math.floor(hostileCreeps.length / 2) < 0) {
             console.log(`Enemy Squad in homeRoom ${homeRoom.name}`);
             // Against squads we need two units (ranged for spread out dmg and melee for single target damage)
-            const body = PopulationManagement.createPartsArray([ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
+            const attackerBody = PopulationManagement.createPartsArray([ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
             Memory.empire.spawnAssignments.push({
                 designee: homeRoom.name,
-                body: body,
+                body: attackerBody,
                 memoryOptions: {
-                    role: Role.PROTECTOR,
+                    role: Role.RAMPART_PROTECTOR,
                     room: homeRoom.name,
                     assignment: homeRoom.name,
                     currentTaskPriority: Priority.HIGH,
+                    combat: { flee: false },
+                },
+            });
+            const rangedBody = PopulationManagement.createPartsArray([RANGED_ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
+            Memory.empire.spawnAssignments.push({
+                designee: homeRoom.name,
+                body: rangedBody,
+                memoryOptions: {
+                    role: Role.RAMPART_PROTECTOR,
+                    room: homeRoom.name,
+                    currentTaskPriority: Priority.MEDIUM,
                     combat: { flee: false },
                 },
             });

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -79,8 +79,11 @@ export function driveRoom(room: Room) {
         }
 
         runTowers(room);
-        runHomeSecurity(room);
-        driveRemoteRoom(room);
+        const isHomeUnderAttack = runHomeSecurity(room);
+        if (!isHomeUnderAttack) {
+            // Prioritize home defense
+            driveRemoteRoom(room);
+        }
 
         if (room.memory.anchorPoint) {
             let anchorPoint = posFromMem(room.memory.anchorPoint);
@@ -120,7 +123,7 @@ function runTowers(room: Room) {
         : towers.forEach((tower) => tower.attack(tower.pos.findClosestByRange(hostileCreeps)));
 }
 
-function runHomeSecurity(homeRoom: Room) {
+function runHomeSecurity(homeRoom: Room): boolean {
     const hostileCreeps = homeRoom.find(FIND_HOSTILE_CREEPS);
     let minNumHostileCreeps = homeRoom.controller.level < 4 ? 1 : 2;
 
@@ -155,7 +158,9 @@ function runHomeSecurity(homeRoom: Room) {
                 },
             });
         }
+        return true;
     }
+    return false;
 }
 
 export function initRoom(room: Room) {

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -45,6 +45,14 @@ Room.prototype.canSpawn = function (this: Room): boolean {
     return this.find(FIND_MY_STRUCTURES).filter((structure) => structure.structureType === STRUCTURE_SPAWN).length > 0;
 };
 
+Object.defineProperty(Room.prototype, 'creeps', {
+    get: function (this: Room) {
+        return Object.values(Game.creeps).filter((creep) => creep.memory.room === this.name);
+    },
+    enumerable: false,
+    configurable: true,
+});
+
 Object.defineProperty(Room.prototype, 'mineral', {
     get: function (this: Room) {
         return this.find(FIND_MINERALS).pop();

--- a/src/roles/protector.ts
+++ b/src/roles/protector.ts
@@ -10,7 +10,11 @@ export class Protector extends CombatCreep {
             return; // Wait while creep is healing
         }
         if (this.travelToRoom(this.memory.assignment) === IN_ROOM) {
-            if (!this.memory.targetId || !Game.getObjectById(this.memory.targetId)) {
+            if (
+                !this.memory.targetId ||
+                !Game.getObjectById(this.memory.targetId) ||
+                Game.getObjectById(this.memory.targetId).pos.roomName !== this.memory.assignment
+            ) {
                 this.memory.targetId = this.findTarget();
             }
             if (!this.memory.targetId) {

--- a/src/roles/protector.ts
+++ b/src/roles/protector.ts
@@ -1,4 +1,3 @@
-import { Pathing } from '../modules/pathing';
 import { CombatCreep } from '../virtualCreeps/combatCreep';
 
 export class Protector extends CombatCreep {
@@ -11,7 +10,7 @@ export class Protector extends CombatCreep {
             return; // Wait while creep is healing
         }
         if (this.travelToRoom(this.memory.assignment) === IN_ROOM) {
-            if (!this.memory.targetId || this.memory.assignment === this.homeroom?.name || !Game.getObjectById(this.memory.targetId)) {
+            if (!this.memory.targetId || !Game.getObjectById(this.memory.targetId)) {
                 this.memory.targetId = this.findTarget();
             }
             if (!this.memory.targetId) {
@@ -34,97 +33,6 @@ export class Protector extends CombatCreep {
             if (!this.memory.combat.flee && creepActionReturnCode !== OK && creepActionReturnCode !== ERR_NOT_IN_RANGE) {
                 delete this.memory.targetId;
             }
-        }
-    }
-
-    private combatPathing(target: Creep) {
-        // Prioritize rampart defense
-        if (this.room.name === this.homeroom?.name) {
-            const currentRange = this.pos.getRangeTo(target);
-            if (currentRange === 1) {
-                return; // already in position
-            }
-            // After attackers are gone creep can leave rampart
-            if (
-                this.room.find(FIND_HOSTILE_CREEPS, {
-                    filter: (creep: Creep) => creep.body.some((bodyPart) => bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK),
-                })
-            ) {
-                // TODO: how to check for breach? If breach then also do not do this
-                const myRamparts = this.room
-                    .find(FIND_STRUCTURES)
-                    .filter(
-                        (structure) =>
-                            structure.structureType === STRUCTURE_RAMPART &&
-                            this.room.memory.miningAssignments[structure.pos.toMemSafe()] === undefined
-                    );
-                if (myRamparts.length) {
-                    // Get closest rampart to the enemy that isn't already taken
-                    let closestRampart = myRamparts.find((rampart) => Pathing.sameCoord(rampart.pos, this.pos))?.pos;
-                    // Avoid going towards the enemy when going to closer rampart
-                    let customMatrixCosts: CustomMatrixCost[] = [];
-                    if (closestRampart) {
-                        this.room
-                            .lookAtArea(this.pos.y - 1, this.pos.x - 1, this.pos.y + 1, this.pos.x + 1, true)
-                            .filter(
-                                (lookObject) =>
-                                    (lookObject.terrain === 'plain' || lookObject.terrain === 'swamp') &&
-                                    lookObject.structure?.structureType !== STRUCTURE_RAMPART &&
-                                    currentRange > target.pos.getRangeTo(lookObject.x, lookObject.y)
-                            )
-                            .forEach((avoidPosition) => {
-                                // Ensure that even if there is swamp on the inside that the creep should prefer staying "indoors"
-                                if (avoidPosition.terrain === 'plain') {
-                                    customMatrixCosts.push({ x: avoidPosition.x, y: avoidPosition.y, cost: 10 });
-                                } else {
-                                    customMatrixCosts.push({ x: avoidPosition.x, y: avoidPosition.y, cost: 50 });
-                                }
-                            });
-                    }
-
-                    myRamparts
-                        .filter((rampart) => !rampart.pos.lookFor(LOOK_CREEPS).some((creep) => creep.memory.role === Role.PROTECTOR))
-                        .forEach((emptyRamparts) => {
-                            if (!closestRampart || emptyRamparts.pos.getRangeTo(target.pos) < closestRampart.getRangeTo(target.pos)) {
-                                closestRampart = emptyRamparts.pos;
-                            }
-                        });
-
-                    if (closestRampart) {
-                        return this.travelTo(closestRampart, { customMatrixCosts: customMatrixCosts });
-                    }
-                }
-            }
-        }
-
-        if (this.memory.combat.flee) {
-            // TODO: In homeroom this will not work ==> Shouldnt matter as soon as ramparts are up but otherwise move to spawn?
-            // Go back to the exit toward creeps homeroom while avoiding creeps along the way
-            return this.travelToRoom(this.homeroom?.name, { ignoreCreeps: false, avoidSourceKeepers: true });
-        }
-
-        if (this.getActiveBodyparts(ATTACK)) {
-            return this.travelTo(target, { ignoreCreeps: false, reusePath: 0, range: 1 });
-        } else if (this.getActiveBodyparts(RANGED_ATTACK)) {
-            let range = 3;
-            const exitCost = 10;
-            let shouldFlee = true;
-
-            const hostilesInSquadRange = this.pos.findInRange(FIND_HOSTILE_CREEPS, 3); // check around target for proper massAttack pathing
-            const rangeToTarget = this.pos.getRangeTo(target);
-
-            // If not in range, an enemy squad with RANGED_ATTACK, or no dangerous creeps, then go closer to enable massAttack
-            if (
-                rangeToTarget > range ||
-                (hostilesInSquadRange.length > 1 && hostilesInSquadRange.some((creep) => creep.getActiveBodyparts(RANGED_ATTACK))) ||
-                !hostilesInSquadRange.some((creep) => creep.getActiveBodyparts(RANGED_ATTACK) || creep.getActiveBodyparts(ATTACK))
-            ) {
-                range = 1;
-                shouldFlee = false;
-            } else if (!target.getActiveBodyparts(ATTACK)) {
-                range = 2; // Against other RANGED_ATTACK units to keep them from fleeing
-            }
-            return this.travelTo(target, { ignoreCreeps: false, reusePath: 0, range: range, flee: shouldFlee, exitCost: exitCost });
         }
     }
 

--- a/src/roles/rampartProtector.ts
+++ b/src/roles/rampartProtector.ts
@@ -1,0 +1,112 @@
+import { Pathing } from '../modules/pathing';
+import { CombatCreep } from '../virtualCreeps/combatCreep';
+
+export class RampartProtector extends CombatCreep {
+    protected run() {
+        if (this.hits < this.hitsMax && this.getActiveBodyparts(HEAL)) {
+            this.heal(this);
+        }
+
+        // First find the targetedRampart. If none is present (for example gcl < 4), then find the hostileCreep
+        if (!this.memory.targetId) {
+            const hostileCreepId = this.findTarget();
+            this.memory.targetId = this.getTargetedRampart(hostileCreepId);
+            if (!this.memory.targetId) {
+                this.memory.targetId = hostileCreepId;
+            }
+        }
+        if (!this.memory.targetId) {
+            this.memory.currentTaskPriority = Priority.LOW;
+            return;
+        }
+        this.memory.currentTaskPriority = Priority.HIGH;
+        const target = Game.getObjectById(this.memory.targetId);
+
+        let creepActionReturnCode: CreepActionReturnCode;
+        if (target instanceof StructureRampart) {
+            const targetCreep = Game.getObjectById(this.findTarget());
+            this.pathingToRampart(target);
+            creepActionReturnCode = this.attackCreep(targetCreep);
+        } else if (target instanceof Creep) {
+            this.combatPathing(target);
+            creepActionReturnCode = this.attackCreep(target);
+        }
+
+        if (creepActionReturnCode !== OK) {
+            delete this.memory.targetId;
+        }
+    }
+
+    private pathingToRampart(targetRampart: StructureRampart) {
+        // Already at target
+        if (!targetRampart || Pathing.sameCoord(this.pos, targetRampart.pos)) {
+            return;
+        }
+        this.travelTo(targetRampart);
+    }
+
+    private findTarget(): Id<Creep> {
+        const hostileCreeps = this.room.find(FIND_HOSTILE_CREEPS);
+        if (hostileCreeps.length) {
+            const closestDangerousHostile = this.pos.findClosestByRange(hostileCreeps, {
+                filter: (creep: Creep) =>
+                    creep.body.some((bodyPart) => bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK || bodyPart.type === WORK),
+            });
+
+            if (closestDangerousHostile) {
+                return closestDangerousHostile.id;
+            }
+        }
+    }
+
+    /**
+     * Check all ramparts to find the one that is being attacked and does not yet have a defender
+     * @returns
+     */
+    private getTargetedRampart(hostileCreepId: Id<Creep>): Id<StructureRampart> {
+        if (hostileCreepId) {
+            const myRamparts = this.room
+                .find(FIND_STRUCTURES)
+                .filter(
+                    (structure) =>
+                        structure.structureType === STRUCTURE_RAMPART && this.room.memory.miningAssignments[structure.pos.toMemSafe()] === undefined
+                ) as StructureRampart[];
+
+            if (myRamparts.length) {
+                const targetedRampart = myRamparts.find((rampart) =>
+                    this.room
+                        .lookAtArea(rampart.pos.y - 1, rampart.pos.x - 1, rampart.pos.y + 1, rampart.pos.x + 1, true)
+                        .find(
+                            (lookObject) =>
+                                lookObject.type === LOOK_CREEPS &&
+                                lookObject.creep?.owner?.username !== this.owner.username &&
+                                !rampart.pos.lookFor(LOOK_CREEPS).some((creep) => creep.memory.role === Role.RAMPART_PROTECTOR)
+                        )
+                );
+
+                if (targetedRampart) {
+                    return targetedRampart.id;
+                }
+
+                // Get closest rampart to the enemy that isn't already taken
+                const closestHostile = Game.getObjectById(hostileCreepId);
+                let closestRampartToHostile = myRamparts.find((rampart) => Pathing.sameCoord(rampart.pos, this.pos));
+
+                myRamparts
+                    .filter((rampart) => !rampart.pos.lookFor(LOOK_CREEPS).some((creep) => creep.memory.role === Role.PROTECTOR))
+                    .forEach((emptyRamparts) => {
+                        if (
+                            !closestRampartToHostile ||
+                            emptyRamparts.pos.getRangeTo(closestHostile.pos) < closestRampartToHostile.pos.getRangeTo(closestHostile.pos)
+                        ) {
+                            closestRampartToHostile = emptyRamparts;
+                        }
+                    });
+
+                if (closestRampartToHostile) {
+                    return closestRampartToHostile.id;
+                }
+            }
+        }
+    }
+}

--- a/src/roles/rampartProtector.ts
+++ b/src/roles/rampartProtector.ts
@@ -46,15 +46,7 @@ export class RampartProtector extends CombatCreep {
             return;
         }
 
-        let customMatrixCosts: CustomMatrixCost[] = [];
-        this.room
-            .find(FIND_MY_STRUCTURES)
-            .filter((struct) => struct.structureType === STRUCTURE_RAMPART)
-            .forEach((rampart) => {
-                customMatrixCosts.push({ x: rampart.pos.x, y: rampart.pos.y, cost: 1 });
-            });
-
-        this.travelTo(targetRampart, { customMatrixCosts: customMatrixCosts });
+        this.travelTo(targetRampart, { preferRamparts: true });
     }
 
     private findTarget(): Id<Creep> {


### PR DESCRIPTION
- Separated protectors and rampart defenders
- spawning rampart defenders unlimited based on the number of enemy squads
- rampart defenders do not always make it into the rampart without getting hit (especially earlier gcls), so towers will not focus on healing creeps back to full in order to deal max damage
- Pathing adjusted to simply prefer walking over ramparts (with single border ramparts it can still rarely happen that a creep will move outside if it needs to readjust - hopefully the towers will be enough to keep it at max health)
- Added a check to the normal protectors to not chase enemies into the next room but instead stay in assigned room