### PR TITLE
Melvin sandbox

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,8 @@ declare global {
     //key is made out of roomName + orientation + anchor
     var quadMatrix: { [key: string]: CustomMatrixCost[] };
 
+    var duoMatrix: { [key: string]: CustomMatrixCost[] };
+
     //resource maps to first qualifying purchase order
     var qualifyingMarketOrders: { [resource: string]: string };
 }

--- a/src/interfaces/combat.ts
+++ b/src/interfaces/combat.ts
@@ -1,0 +1,17 @@
+interface CreepCombatData {
+    totalDmg: number; // Total damage (ignores attack if not in range)
+    attack: number;
+    ranged: number;
+    heal: number;
+    dmgMultiplier: number; // coming from boosted TOUGH (tier 1 ==> 0.7)
+    count: number; // Number of creeps in the room
+}
+
+interface TowerCombatData {
+    minDmg: number;
+    maxDmg: number;
+    dmgAtPos?: number;
+    minHeal: number;
+    maxHeal: number;
+    healAtPos?: number;
+}

--- a/src/modules/combatIntel.ts
+++ b/src/modules/combatIntel.ts
@@ -1,0 +1,171 @@
+export class CombatIntel {
+    private static towerMaxRange = 20;
+    private static towerMinRange = 5;
+    private static towerMaxDmg = 600;
+    private static towerMinDmg = 150;
+    private static towerMaxHeal = 400;
+    private static towerMinHeal = 100;
+
+    /**
+     * Get tower combat data by room.
+     * @param room Targetroom
+     * @param forHostile Get hostile or own tower combat data
+     * @param pos Optional roomPosition for which to calculate the combat data
+     * @returns
+     */
+    public static getTowerCombatData(room: Room, forHostile: boolean, pos?: RoomPosition): TowerCombatData {
+        const towers = room.find(forHostile ? FIND_HOSTILE_STRUCTURES : FIND_MY_STRUCTURES, {
+            filter: (struct) => struct.structureType === STRUCTURE_TOWER,
+        }) as StructureTower[];
+
+        if (!towers) {
+            return;
+        }
+
+        let combatData: TowerCombatData = {
+            minDmg: towers.length * this.towerMinDmg,
+            maxDmg: towers.length * this.towerMaxDmg,
+            minHeal: towers.length * this.towerMinHeal,
+            maxHeal: towers.length * this.towerMaxHeal,
+        };
+
+        if (!pos) {
+            return combatData;
+        }
+
+        combatData.dmgAtPos = this.calculateTotal(towers, pos, this.towerMinDmg, this.towerMaxDmg);
+        combatData.healAtPos = this.calculateTotal(towers, pos, this.towerMinHeal, this.towerMaxHeal);
+        return combatData;
+    }
+
+    /**
+     * Calculate total amount of damage enemy creeps can do (to creeps and structures).
+     * This will not include already destroyed body parts.
+     * @param room
+     * @param pos
+     * @returns
+     */
+    public static getCreepCombatData(room: Room, forHostile: boolean, pos?: RoomPosition): CreepCombatData {
+        const hostileCreeps = room.find(forHostile ? FIND_HOSTILE_CREEPS : FIND_MY_CREEPS, {
+            filter: (creep: Creep) =>
+                (!Memory.empire.playersToIgnore?.includes(creep.owner.username) && creep.getActiveBodyparts(RANGED_ATTACK)) ||
+                creep.getActiveBodyparts(ATTACK) ||
+                creep.getActiveBodyparts(HEAL),
+        }) as Creep[];
+
+        if (!hostileCreeps) {
+            return;
+        }
+
+        if (!pos) {
+            return this.calculateCreepsCombatData(hostileCreeps);
+        }
+
+        return this.calculateCreepsCombatData(hostileCreeps, pos);
+    }
+
+    /**
+     * Calculate total Tower Damage based on range instead of a specific RoomPosition.
+     * @param combatData CombatData calculated by getTowerCombatData
+     * @param range targetRange
+     * @returns Damage at specified range
+     */
+    public static towerDamageAtRange(combatData: TowerCombatData, range: number): number {
+        const interval = (this.towerMaxDmg - this.towerMinDmg) / (this.towerMaxRange - this.towerMinRange); // Damage diff between ranges
+        if (range >= this.towerMaxRange) {
+            return combatData.minDmg;
+        } else if (range <= this.towerMinRange) {
+            return combatData.maxDmg;
+        }
+        return combatData.maxDmg - (range - this.towerMinRange) * interval;
+    }
+
+    /**
+     * Calculate total Dmg/Heal from all towers at the specified position.
+     * @param towers own/hostile towers
+     * @param pos target roomposition
+     * @param min dmg/heal minimum
+     * @param max dmg/heal maximum
+     * @returns dmg/heal at pos
+     */
+    private static calculateTotal(towers: StructureTower[], pos: RoomPosition, min: number, max: number): number {
+        const interval = (max - min) / (this.towerMaxRange - this.towerMinRange); // Damage diff between ranges
+        return towers.reduce((totalDamage, nextTower) => {
+            const range = nextTower.pos.getRangeTo(pos);
+
+            if (range >= this.towerMaxRange) {
+                return min;
+            } else if (range <= this.towerMinRange) {
+                return max;
+            }
+            return (totalDamage += max - (range - this.towerMinRange) * interval);
+        }, 0);
+    }
+
+    /**
+     * This will always assume single target damage (max damage) and not rangedMassAttack.
+     * @param creeps
+     * @param pos
+     * @returns
+     */
+    private static calculateCreepsCombatData(creeps: Creep[], pos?: RoomPosition): CreepCombatData {
+        let combatData = { totalDmg: 0, attack: 0, ranged: 0, heal: 0, dmgMultiplier: 1, count: creeps.length };
+        creeps.forEach((creep: Creep) => {
+            combatData = this.getTotalDamagePerCreepBody(creep.body, combatData);
+            if (pos) {
+                const range = creep.pos.getRangeTo(pos);
+                if (range === 1) {
+                    combatData.totalDmg += combatData.attack;
+                }
+                if (range <= 3) {
+                    combatData.totalDmg += combatData.ranged;
+                }
+            } else {
+                combatData.totalDmg += combatData.attack + combatData.ranged;
+            }
+        });
+        return combatData;
+    }
+
+    /**
+     * This will calculate the total Damage from ranged and normal attack. It will also check if the body part is boosted or already broken.
+     * @param bodyParts
+     * @param targetBodyPart
+     * @returns
+     */
+    private static getTotalDamagePerCreepBody(bodyParts: BodyPartDefinition[], combatData: CreepCombatData): CreepCombatData {
+        bodyParts
+            .filter(
+                (bodyPart: BodyPartDefinition) =>
+                    (bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK || bodyPart.type === HEAL) && bodyPart.hits
+            )
+            .forEach((bodyPart: BodyPartDefinition) => {
+                let boost = 1;
+                if (bodyPart.type === ATTACK) {
+                    if (bodyPart.boost) {
+                        boost = BOOSTS.attack[bodyPart.boost].attack;
+                    }
+                    combatData.attack += 30 * boost;
+                } else if (bodyPart.type === RANGED_ATTACK) {
+                    if (bodyPart.boost) {
+                        boost = BOOSTS.ranged_attack[bodyPart.boost].rangedAttack;
+                    }
+                    combatData.ranged += 30 * boost;
+                } else if (bodyPart.type === HEAL) {
+                    if (bodyPart.boost) {
+                        boost = BOOSTS.heal[bodyPart.boost].heal;
+                    }
+                    combatData.heal += 12 * boost;
+                } else if (bodyPart.type === TOUGH) {
+                    if (bodyPart.boost) {
+                        boost = BOOSTS.tough[bodyPart.boost].damage;
+                    }
+                    // Set the highest boost since the damage needs to exceed this
+                    if (combatData.dmgMultiplier > boost) {
+                        combatData.dmgMultiplier = boost;
+                    }
+                }
+            });
+        return combatData;
+    }
+}

--- a/src/modules/flagsManagement.ts
+++ b/src/modules/flagsManagement.ts
@@ -1,6 +1,5 @@
 import { addHostileRoom, unclaimRoom } from './empireManagement';
 import { addOperation, findOperationOrigin } from './operationsManagement';
-import { PopulationManagement } from './populationManagement';
 
 export default function manageFlags() {
     if (Game.flags.colonize) {

--- a/src/modules/roomDesign.ts
+++ b/src/modules/roomDesign.ts
@@ -372,12 +372,7 @@ export function placeMinerLinks(room: Room) {
                 if (linkNeeded) {
                     let looks = room.lookAtArea(assignmentPos.y - 1, assignmentPos.x - 1, assignmentPos.y + 1, assignmentPos.x + 1, true);
                     let availableSpot = looks.find(
-                        (look) =>
-                            look.type === 'terrain' &&
-                            look.terrain !== 'wall' &&
-                            !looks.some(
-                                (otherLook) => otherLook.x === look.x && otherLook.y === look.y && (otherLook.constructionSite || otherLook.structure)
-                            )
+                        (look) => look.type === 'terrain' && look.terrain !== 'wall' && !look.structure && !look.constructionSite
                     );
 
                     room.createConstructionSite(availableSpot.x, availableSpot.y, STRUCTURE_LINK);

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -1,5 +1,4 @@
-import { filter } from 'lodash';
-import { cpuUsage } from 'process';
+import { CombatIntel } from './combatIntel';
 import { runLabs } from './labManagement';
 import { posFromMem } from './memoryManagement';
 import { PopulationManagement } from './populationManagement';
@@ -110,8 +109,8 @@ export function driveRoom(room: Room) {
             }
         }
 
-        runTowers(room);
         const isHomeUnderAttack = runHomeSecurity(room);
+        runTowers(room, isHomeUnderAttack);
         if (!isHomeUnderAttack) {
             // Prioritize home defense
             driveRemoteRoom(room);
@@ -144,12 +143,13 @@ export function driveRoom(room: Room) {
     }
 }
 
-function runTowers(room: Room) {
+function runTowers(room: Room, isRoomUnderAttack: boolean) {
     // @ts-ignore
     let towers: StructureTower[] = room.find(FIND_STRUCTURES).filter((structure) => structure.structureType === STRUCTURE_TOWER);
 
-    // Heal creeps in baseroom. Can be optimized to check how many towers need to heal one creep but usually this should not be needed anyway if our "room under attack" logic works properly.
-    let myHurtCreep = room.find(FIND_MY_CREEPS).find((creep) => creep.hits < creep.hitsMax);
+    let myHurtCreep = room
+        .find(FIND_MY_CREEPS)
+        .find((creep) => creep.hits < creep.hitsMax && (!isRoomUnderAttack || creep.memory.role === Role.RAMPART_PROTECTOR));
     if (myHurtCreep) {
         towers.forEach((tower) => tower.heal(myHurtCreep));
         return;
@@ -162,10 +162,23 @@ function runTowers(room: Room) {
 }
 
 function runHomeSecurity(homeRoom: Room): boolean {
-    const hostileCreeps = homeRoom.find(FIND_HOSTILE_CREEPS, { filter: (creep) => !Memory.empire.playersToIgnore?.includes(creep.owner.username) });
+    const towerData = CombatIntel.getTowerCombatData(homeRoom, false);
+    const hostileCreepData = CombatIntel.getCreepCombatData(homeRoom, true);
+
+    if (hostileCreepData.heal < towerData.minDmg * hostileCreepData.dmgMultiplier) {
+        return; // Towers can handle it for sure
+    }
+
+    if (
+        homeRoom.memory.layout === RoomLayout.BUNKER &&
+        hostileCreepData.heal < CombatIntel.towerDamageAtRange(towerData, 12) * hostileCreepData.dmgMultiplier
+    ) {
+        return; // Closest Creeps in BunkerLayout have to be in a range of 12 if they want to hit the ramparts in any way
+    }
+
     let minNumHostileCreeps = homeRoom.controller.level < 4 ? 1 : 2;
 
-    if (hostileCreeps.length >= minNumHostileCreeps) {
+    if (hostileCreepData.count >= minNumHostileCreeps) {
         // Spawn multiple rampartProtectors based on the number of enemy hostiles
         const currentNumProtectors = PopulationManagement.currentNumRampartProtectors(homeRoom.name);
         if (!currentNumProtectors) {
@@ -174,6 +187,7 @@ function runHomeSecurity(homeRoom: Room): boolean {
                 designee: homeRoom.name,
                 body: body,
                 spawnOpts: {
+                    boosts: [BoostType.RANGED_ATTACK],
                     memory: {
                         role: Role.RAMPART_PROTECTOR,
                         room: homeRoom.name,
@@ -183,7 +197,7 @@ function runHomeSecurity(homeRoom: Room): boolean {
                 },
             });
         }
-        if (hostileCreeps.length >= 4 && currentNumProtectors - Math.floor(hostileCreeps.length / 2) < 0) {
+        if (hostileCreepData.count >= 4 && currentNumProtectors - Math.floor(hostileCreepData.count / 2) < 0) {
             console.log(`Enemy Squad in homeRoom ${homeRoom.name}`);
             // Against squads we need two units (ranged for spread out dmg and melee for single target damage)
             const attackerBody = PopulationManagement.createPartsArray([ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
@@ -191,6 +205,7 @@ function runHomeSecurity(homeRoom: Room): boolean {
                 designee: homeRoom.name,
                 body: attackerBody,
                 spawnOpts: {
+                    boosts: [BoostType.ATTACK],
                     memory: {
                         role: Role.RAMPART_PROTECTOR,
                         room: homeRoom.name,
@@ -205,6 +220,7 @@ function runHomeSecurity(homeRoom: Room): boolean {
                 designee: homeRoom.name,
                 body: rangedBody,
                 spawnOpts: {
+                    boosts: [BoostType.RANGED_ATTACK],
                     memory: {
                         role: Role.RAMPART_PROTECTOR,
                         room: homeRoom.name,


### PR DESCRIPTION
Changes:

- Added Util methods to calculate own/hostile potential combat numbers (heal/attack/ranged/dmgReduction)
- Added boosted rampart defenders
- No longer spawning defenders when turrets can take care of the invaders (calculated using minimumDamage unless it is a bunker layout, then it will use a range of 12 which is the maximum distance the layout can still get attacked)

Todo next:

- Spawn defender with custom body based on amount of damage needed
- Save Threatmanagement to memory so other places can make use of changed behavior 
- Remove defenders from spawnAssignment and move them directly into populationManagement