### PR TITLE
Melvin sandbox

### DIFF
--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -63,6 +63,10 @@ interface TravelToOpts extends PathFinderOpts {
      * Route will prefer Highway (by default enabled).
      */
     preferHighway?: boolean;
+    /**
+     * Creep efficiency to determine best pathing options
+     */
+    efficiency?: number;
 }
 
 interface CustomMatrixCost {

--- a/src/modules/squadManagement.ts
+++ b/src/modules/squadManagement.ts
@@ -207,9 +207,14 @@ export class SquadManagement {
             } else {
                 const target = this.findPathingTarget();
                 if (target instanceof Creep) {
-                    this.squadLeader.travelTo(target, { range: range });
+                    this.squadLeader.travelTo(target, { range: range, maxRooms: 1 });
                 } else {
-                    this.squadLeader.travelTo(target, { range: 1, ignoreStructures: true, customMatrixCosts: this.getDuoMatrix(this.squadLeader) });
+                    this.squadLeader.travelTo(target, {
+                        range: 1,
+                        ignoreStructures: true,
+                        maxRooms: 1,
+                        customMatrixCosts: this.getDuoMatrix(this.squadLeader),
+                    });
                 }
             }
             this.squadFollower.move(this.squadFollower.pos.getDirectionTo(this.squadLeader));

--- a/src/modules/squadManagement.ts
+++ b/src/modules/squadManagement.ts
@@ -43,15 +43,15 @@ export class SquadManagement {
         this.squadSecondFollower = Game.creeps[Memory.empire.squads[this.squadId]?.members[SquadMemberType.SQUAD_SECOND_FOLLOWER]] as CombatCreep;
     }
 
-    public isPartOfDuo() {
+    private isPartOfDuo() {
         return Memory.empire.squads[this.squadId].squadType === SquadType.DUO;
     }
 
-    public isPartOfQuad() {
+    private isPartOfQuad() {
         return Memory.empire.squads[this.squadId].squadType === SquadType.QUAD;
     }
 
-    public missingCreeps() {
+    private missingCreeps() {
         if (this.isPartOfDuo()) {
             return !this.squadLeader || !this.squadFollower;
         }
@@ -65,7 +65,7 @@ export class SquadManagement {
         return Math.abs(this.lastRun - Game.time) > 0;
     }
 
-    public getInFormation(): boolean {
+    private getInFormation(): boolean {
         if (this.isInFormation()) {
             return true;
         }
@@ -103,7 +103,7 @@ export class SquadManagement {
         this.squadSecondFollower.memory.currentTaskPriority = Priority.LOW;
     }
 
-    public getInLineFormation(): boolean {
+    private getInLineFormation(): boolean {
         if (this.isInLineFormation()) {
             return true;
         }
@@ -117,7 +117,7 @@ export class SquadManagement {
         return this.isSquadOnExit(); // While on exit count as true so it wont get blocked by own creeps
     }
 
-    public formationPathing(range: number): void {
+    private formationPathing(range: number): void {
         if (this.onFirstCreep()) {
             if (this.isSquadFatigued()) {
                 return;
@@ -173,7 +173,26 @@ export class SquadManagement {
         }
     }
 
-    public duoPathing(range: number) {
+    public static splitQuadIntoDuos(squadId: string) {
+        const currentSquadMem = Memory.empire.squads[squadId];
+        const newSquadId = squadId + '2';
+
+        let newSquadMem = currentSquadMem;
+        newSquadMem.members.squadLeader = currentSquadMem.members.squadSecondLeader;
+        newSquadMem.members.squadFollower = currentSquadMem.members.squadSecondFollower;
+        delete newSquadMem.members.squadSecondLeader;
+        delete newSquadMem.members.squadSecondFollower;
+        newSquadMem.squadType = SquadType.DUO;
+        delete currentSquadMem.members.squadSecondLeader;
+        delete currentSquadMem.members.squadSecondFollower;
+        delete Game.creeps[currentSquadMem.members.squadLeader].memory._m.path;
+        currentSquadMem.squadType = SquadType.DUO;
+
+        Memory.empire.squads[newSquadId] = newSquadMem;
+        Memory.empire.squads[squadId] = currentSquadMem;
+    }
+
+    private duoPathing(range: number) {
         if (this.onFirstCreep()) {
             if (this.isSquadFatigued()) {
                 return;
@@ -335,7 +354,7 @@ export class SquadManagement {
         return;
     }
 
-    public inTargetRoom(): boolean {
+    private inTargetRoom(): boolean {
         const targetRoom = this.assignment;
         return (
             this.squadLeader.pos.roomName === targetRoom ||
@@ -410,7 +429,7 @@ export class SquadManagement {
         }
     }
 
-    public getDuoMatrix(creep: Creep): CustomMatrixCost[] {
+    private getDuoMatrix(creep: Creep): CustomMatrixCost[] {
         const roomName = creep.room.name;
         if (!global.duoMatrix) {
             global.duoMatrix = {};
@@ -438,7 +457,7 @@ export class SquadManagement {
         return global.duoMatrix[roomName];
     }
 
-    public static getQuadMatrix(
+    private static getQuadMatrix(
         creep: Creep,
         assignment: string,
         orientation: TOP | RIGHT | BOTTOM | LEFT,
@@ -626,7 +645,7 @@ export class SquadManagement {
         this.cleanUp();
     }
 
-    public linePathing(): void {
+    private linePathing(): void {
         if (this.onFirstCreep()) {
             if (this.isSquadFatigued()) {
                 return;
@@ -711,7 +730,7 @@ export class SquadManagement {
         return result;
     }
 
-    public getInDuoFormation(): boolean {
+    private getInDuoFormation(): boolean {
         if (this.isInDuoFormation()) {
             return true;
         }
@@ -722,7 +741,7 @@ export class SquadManagement {
         return this.squadLeader.pos.isNearTo(this.squadFollower) || this.squadLeader.onEdge() || this.squadFollower.onEdge();
     }
 
-    public closeToTargetRoom(): boolean {
+    private closeToTargetRoom(): boolean {
         if (this.forcedDestinations?.length) {
             return false;
         }
@@ -783,7 +802,7 @@ export class SquadManagement {
         return targetCreep;
     }
 
-    public cleanUp() {
+    private cleanUp() {
         if (this.onFirstCreep()) {
             Memory.empire.squads[this.squadId].lastRun = Game.time;
             Memory.empire.squads[this.squadId].isFleeing = this.isFleeing;
@@ -874,7 +893,7 @@ export class SquadManagement {
         }
     }
 
-    public fleeing(): void {
+    private fleeing(): void {
         if (this.currentCreep.pos.roomName === this.assignment) {
             // Creep died
             this.currentCreep.flee();

--- a/src/roles/squadAttacker.ts
+++ b/src/roles/squadAttacker.ts
@@ -71,10 +71,7 @@ export class SquadAttacker extends CombatCreep {
                     return enemyStructure[0];
                 }
             }
-            const obstacleStructure = sq.getObstacleStructure();
-            if (obstacleStructure) {
-                return obstacleStructure;
-            }
+
             let target: any;
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
@@ -86,6 +83,12 @@ export class SquadAttacker extends CombatCreep {
                     filter: (struct) => struct.structureType === STRUCTURE_SPAWN,
                 });
             }
+
+            const obstacleStructure = sq.getObstacleStructure();
+            if (obstacleStructure && (!target || this.pos.getRangeTo(target) > range)) {
+                return obstacleStructure;
+            }
+
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
             }
@@ -116,10 +119,6 @@ export class SquadAttacker extends CombatCreep {
                 }
             }
 
-            const obstacleStructure = sq.getObstacleStructure();
-            if (obstacleStructure) {
-                return obstacleStructure;
-            }
             let target: any;
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
@@ -135,6 +134,11 @@ export class SquadAttacker extends CombatCreep {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
                     filter: (struct) => struct.structureType === STRUCTURE_KEEPER_LAIR,
                 });
+            }
+
+            const obstacleStructure = sq.getObstacleStructure();
+            if (obstacleStructure && (!target || this.pos.getRangeTo(target) > 1)) {
+                return obstacleStructure;
             }
             return target;
         }

--- a/src/roles/squadAttacker.ts
+++ b/src/roles/squadAttacker.ts
@@ -49,16 +49,17 @@ export class SquadAttacker extends CombatCreep {
 
     private findPriorityAttackTarget(range: number, sq: SquadManagement) {
         const areaInRange = Pathing.getArea(this.pos, range);
-        const unprotectedHostileCreep = this.room
-            .lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true)
-            .filter(
-                (lookObject) =>
-                    lookObject.type === LOOK_CREEPS &&
-                    lookObject.creep?.owner?.username !== this.owner.username &&
-                    !lookObject.creep?.spawning &&
-                    lookObject.structure?.structureType !== STRUCTURE_RAMPART &&
-                    lookObject.structure?.structureType !== STRUCTURE_KEEPER_LAIR
-            );
+        const lookAtArea = this.room.lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true);
+        const hostileCreep = lookAtArea.filter(
+            (lookObject) =>
+                lookObject.type === LOOK_CREEPS && lookObject.creep?.owner?.username !== this.owner.username && !lookObject.creep?.spawning
+        );
+        const unprotectedHostileCreep = lookAtArea.filter(
+            (lookObject) =>
+                lookObject.type === LOOK_STRUCTURES &&
+                lookObject.structure.structureType !== STRUCTURE_RAMPART &&
+                hostileCreep.some((look) => look.creep.pos.x === lookObject.structure.pos.x && look.creep.pos.y === lookObject.structure.pos.y)
+        );
         if (unprotectedHostileCreep.length) {
             return unprotectedHostileCreep[0].creep;
         }
@@ -94,7 +95,7 @@ export class SquadAttacker extends CombatCreep {
             }
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
-                    filter: (struct) => struct.structureType === STRUCTURE_KEEPER_LAIR,
+                    filter: (struct) => struct.structureType !== STRUCTURE_KEEPER_LAIR && struct.structureType !== STRUCTURE_CONTROLLER,
                 });
             }
             return target;
@@ -119,6 +120,16 @@ export class SquadAttacker extends CombatCreep {
                 }
             }
 
+            const targetStructure = sq.targetStructure ? Game.getObjectById(sq.targetStructure) : undefined;
+            if (targetStructure && this.pos.getRangeTo(targetStructure) === 1) {
+                return targetStructure;
+            } else if (targetStructure) {
+                const obstacleStructure = sq.getObstacleStructure();
+                if (obstacleStructure) {
+                    return obstacleStructure;
+                }
+            }
+
             let target: any;
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
@@ -132,14 +143,15 @@ export class SquadAttacker extends CombatCreep {
             }
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
-                    filter: (struct) => struct.structureType === STRUCTURE_KEEPER_LAIR,
+                    filter: (struct) => struct.hits > 0 && struct.hits < 50000,
+                });
+            }
+            if (!target) {
+                target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
+                    filter: (struct) => struct.hits > 0,
                 });
             }
 
-            const obstacleStructure = sq.getObstacleStructure();
-            if (obstacleStructure && (!target || this.pos.getRangeTo(target) > 1)) {
-                return obstacleStructure;
-            }
             return target;
         }
     }


### PR DESCRIPTION
Changes:

- Manual methods to split and combine quads/duos (not yet called automatically anywhere but can be called from console)
- Improved targeting so that it will slide/rotate toward the target if only one of the leaders is in range
- Remove efficiency until pathing is completely overhauled since it can result in going back and forth currently and also does not provide many improvements since only the leader path is being considered
- fixed a ton of "lookObject" methods (unprotected hostiles have not been tested due to missing enemies :D)
- Targeting prefers lower hp targets before clearing walls/ramparts (does not check if the target is protected by a rampart)
