### PR TITLE
Melee Protector spawning/pathing/healing

### DIFF
--- a/src/roles/protector.ts
+++ b/src/roles/protector.ts
@@ -2,15 +2,12 @@ import { CombatCreep } from '../virtualCreeps/combatCreep';
 
 export class Protector extends CombatCreep {
     protected run() {
-        if ((this.hits < this.hitsMax || this.memory.targetId) && this.getActiveBodyparts(HEAL)) {
-            this.heal(this);
-        }
-
         if (!this.getActiveBodyparts(RANGED_ATTACK) && !this.getActiveBodyparts(ATTACK)) {
             this.memory.combat.flee = true;
         }
 
         if (this.fledToNewRoom()) {
+            this.healSelf(false);
             return; // Wait while creep is healing
         }
         if (this.travelToRoom(this.memory.assignment) === IN_ROOM || this.memory.targetId) {
@@ -22,6 +19,7 @@ export class Protector extends CombatCreep {
                 this.memory.targetId = this.findTarget();
             }
             if (!this.memory.targetId) {
+                this.healSelf(false);
                 return;
             }
             const target = Game.getObjectById(this.memory.targetId);
@@ -40,7 +38,15 @@ export class Protector extends CombatCreep {
             // Enable retargeting on same tick
             if (!this.memory.combat.flee && creepActionReturnCode !== OK && creepActionReturnCode !== ERR_NOT_IN_RANGE) {
                 delete this.memory.targetId;
+            } else if (creepActionReturnCode === OK) {
+                this.healSelf(!!this.getActiveBodyparts(ATTACK));
             }
+        }
+    }
+
+    private healSelf(hasMeleeAttacked: boolean) {
+        if (!hasMeleeAttacked && (this.hits < this.hitsMax || this.memory.targetId) && this.getActiveBodyparts(HEAL)) {
+            this.heal(this);
         }
     }
 

--- a/src/virtualCreeps/combatCreep.ts
+++ b/src/virtualCreeps/combatCreep.ts
@@ -31,6 +31,10 @@ export class CombatCreep extends WaveCreep {
         }
 
         if (this.getActiveBodyparts(ATTACK)) {
+            if (this.pos.isNearTo(target)) {
+                // Close Range movement to stick to the enemy
+                return this.move(this.pos.getDirectionTo(target));
+            }
             return this.travelTo(target, { ignoreCreeps: false, reusePath: 0, range: 1 });
         } else if (this.getActiveBodyparts(RANGED_ATTACK)) {
             let range = 3;


### PR DESCRIPTION
Made it so that melee protectors will stick to their target and heal no longer overrides attacking. Also, for non_combat creeps it will spawn melee protectors in order to safe on energy.
These changes have not been tested (only that protectors correctly attack invader cores), so do check if the defense works against non_combat units. If not we will have to changes that to ranged_attack and lower the "damageNeeded".

Also, slightly increased the threshold before using boosts to safe on minerals.