### PR TITLE
Melvin sandbox

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -8,7 +8,7 @@ interface CreepMemory {
     link?: Id<StructureLink>;
     destination?: string;
     assignment?: string;
-    targetId?: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin>;
+    targetId?: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> | Id<Mineral>;
     miningPos?: string;
     hasTTLReplacement?: boolean;
     gathering?: boolean;
@@ -86,4 +86,5 @@ const enum Role {
     MINERAL_MINER = 'MINERAL_MINER',
     INTERSHARD_TRAVELLER = 'INTERSHARD_TRAVELLER',
     KEEPER_EXTERMINATOR = 'KEEPER_EXTERMINATOR',
+    REMOTE_MINERAL_MINER = 'REMOTE_MINERAL_MINER',
 }

--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -67,6 +67,10 @@ interface TravelToOpts extends PathFinderOpts {
      * Creep efficiency to determine best pathing options
      */
     efficiency?: number;
+    /**
+     * Additional goals (see PathFinder.search)
+     */
+    goals?: { pos: RoomPosition; range: number }[];
 }
 
 interface CustomMatrixCost {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -24,12 +24,14 @@ interface RoomMemory {
 
 interface RemoteData {
     reservationState?: RemoteRoomReservationStatus;
-    miningPositions: string[];
+    miningPositions: { [id: Id<Source>]: string }; // sourceId: miningPos
     miner: string;
     gatherer: string;
+    gathererSK?: string;
     reserver?: string;
     threatLevel: RemoteRoomThreatLevel;
     keeperExterminator?: string;
+    sourceKeeperLairs?: { [id: Id<Source>]: Id<Structure<StructureConstant>> }; // keeperId: closestSourceId
 }
 
 interface RoomData {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -1,6 +1,7 @@
 interface RoomMemory {
     needsWallRepair?: boolean;
     upgraderLinkPos?: string;
+    managerLink?: Id<Structure>;
     labRequests?: LabNeed[];
     energyDistance?: number;
     controllerDistance?: number;

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -29,6 +29,8 @@ interface RemoteData {
     gatherer: string;
     gathererSK?: string;
     reserver?: string;
+    mineralMiner?: string;
+    mineralAvailableAt?: number;
     threatLevel: RemoteRoomThreatLevel;
     keeperExterminator?: string;
     sourceKeeperLairs?: { [id: Id<Source>]: Id<Structure<StructureConstant>> }; // keeperId: closestSourceId

--- a/src/interfaces/structureSpawn.ts
+++ b/src/interfaces/structureSpawn.ts
@@ -8,6 +8,7 @@ interface StructureSpawn {
     spawnManager(): ScreepsReturnCode;
     spawnWorker(): ScreepsReturnCode;
     spawnKeeperExterminator(remoteRoomName: string): ScreepsReturnCode;
+    spawnRemoteMineralMiner(remoteRoomName: string): ScreepsReturnCode;
     spawnAssignedCreep(assignment: SpawnAssignment): ScreepsReturnCode;
     spawnFirst(partsBlock: BodyPartConstant[], name: string, opts?: SpawnOptions, levelCap?: number): ScreepsReturnCode;
     spawnMax(partsBlock: BodyPartConstant[], name: string, opts?: SpawnOptions, levelCap?: number): ScreepsReturnCode;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import driveCreep from './modules/creepDriver';
 import { addRoomData, updateRoomData } from './modules/data';
 import manageFlags from './modules/flagsManagement';
 import { manageMemory } from './modules/memoryManagement';
-import { getAllRoomNeeds, manageEmpireResources } from './modules/resourceManagement';
+import { manageEmpireResources } from './modules/resourceManagement';
 import { driveRoom } from './modules/roomManagement';
 import { WaveCreep } from './virtualCreeps/waveCreep';
 require('./prototypes/requirePrototypes');

--- a/src/modules/creepDriver.ts
+++ b/src/modules/creepDriver.ts
@@ -19,6 +19,7 @@ import { MineralMiner } from '../roles/mineralMiner';
 import { IntershardTraveler } from '../roles/intershardTraveller';
 import { Upgrader } from '../roles/upgrader';
 import { KeeperExterminator } from '../roles/keeperExterminator';
+import { RemoteMineralMiner } from '../roles/remoteMineralMiner';
 
 export default function driveCreep(creep: Creep) {
     let waveCreep: WaveCreep;
@@ -87,6 +88,9 @@ export default function driveCreep(creep: Creep) {
             break;
         case Role.KEEPER_EXTERMINATOR:
             waveCreep = new KeeperExterminator(creep.id);
+            break;
+        case Role.REMOTE_MINERAL_MINER:
+            waveCreep = new RemoteMineralMiner(creep.id);
             break;
         default:
             waveCreep = new WaveCreep(creep.id);

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -118,6 +118,9 @@ function handleDeadCreep(creepName: string) {
         if (deadCreepMemory.role === Role.KEEPER_EXTERMINATOR) {
             Memory.remoteData[deadCreepMemory.assignment].keeperExterminator = AssignmentStatus.UNASSIGNED;
         }
+        if (deadCreepMemory.role === Role.REMOTE_MINERAL_MINER) {
+            Memory.remoteData[deadCreepMemory.assignment].mineralMiner = AssignmentStatus.UNASSIGNED;
+        }
         if (deadCreepMemory.labRequests) {
             Memory.rooms[deadCreepMemory.room].labRequests.unshift(...deadCreepMemory.labRequests);
         }

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -64,6 +64,10 @@ export function validateAssignments() {
                 Memory.remoteData[remoteRoomName].gatherer = AssignmentStatus.UNASSIGNED;
             }
 
+            if (!Game.creeps[Memory.remoteData[remoteRoomName]?.gathererSK]) {
+                Memory.remoteData[remoteRoomName].gathererSK = AssignmentStatus.UNASSIGNED;
+            }
+
             if (!Game.creeps[Memory.remoteData[remoteRoomName]?.miner]) {
                 Memory.remoteData[remoteRoomName].miner = AssignmentStatus.UNASSIGNED;
             }
@@ -97,9 +101,13 @@ function handleDeadCreep(creepName: string) {
             Memory.rooms[deadCreepMemory.room].remoteMiningRooms?.includes(deadCreepMemory.assignment) &&
             Object.values(Memory.creeps).filter(
                 (creep) => creep.room === deadCreepMemory.room && creep.role === Role.GATHERER && creep.assignment === deadCreepMemory.assignment
-            ).length === 1
+            ).length
         ) {
-            Memory.remoteData[deadCreepMemory.assignment].gatherer = AssignmentStatus.UNASSIGNED;
+            if (Memory.remoteData[deadCreepMemory.assignment].gatherer === creepName) {
+                Memory.remoteData[deadCreepMemory.assignment].gatherer = AssignmentStatus.UNASSIGNED;
+            } else if (Memory.remoteData[deadCreepMemory.assignment].gathererSK === creepName) {
+                Memory.remoteData[deadCreepMemory.assignment].gathererSK = AssignmentStatus.UNASSIGNED;
+            }
         }
         if (deadCreepMemory.role === Role.RESERVER && Memory.rooms[deadCreepMemory.room].remoteMiningRooms?.includes(deadCreepMemory.assignment)) {
             Memory.remoteData[deadCreepMemory.assignment].reserver = AssignmentStatus.UNASSIGNED;

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -319,8 +319,8 @@ export class Pathing {
                     matrix = Pathing.getCreepMatrix(room);
                 }
 
+                matrix = matrix.clone();
                 if (options.avoidSourceKeepers) {
-                    matrix = matrix.clone();
                     if (
                         Memory.remoteData[roomName]?.sourceKeeperLairs ||
                         (!Memory.remoteData[roomName] && room.find(FIND_STRUCTURES).some((struct) => struct.structureType === STRUCTURE_KEEPER_LAIR))
@@ -341,7 +341,6 @@ export class Pathing {
                 }
 
                 if (options.exitCost) {
-                    matrix = matrix.clone();
                     for (let x = 0; x < 50; x++) {
                         if (!Game.map.getRoomTerrain(roomName).get(x, 0)) {
                             matrix.set(x, 0, options.exitCost);
@@ -390,21 +389,18 @@ export class Pathing {
 
                 // All tiles will be set to one if there is a road construction so that it counts as a finished road
                 if (options.preferRoadConstruction) {
-                    matrix = matrix.clone();
                     room.find(FIND_MY_CONSTRUCTION_SITES, { filter: (struct) => struct.structureType === STRUCTURE_ROAD }).forEach((struct) =>
                         matrix.set(struct.pos.x, struct.pos.y, 1)
                     );
                 }
 
                 if (options.preferRamparts) {
-                    matrix = matrix.clone();
                     room.find(FIND_MY_STRUCTURES, { filter: (struct) => struct.structureType === STRUCTURE_RAMPART }).forEach((rampart) => {
                         matrix.set(rampart.pos.x, rampart.pos.y, 1);
                     });
                 }
 
                 if (options.customMatrixCosts) {
-                    matrix = matrix.clone();
                     options.customMatrixCosts.forEach((matrixCost) => matrix.set(matrixCost.x, matrixCost.y, matrixCost.cost));
                 }
             }

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -254,7 +254,7 @@ export class Pathing {
         const range = Pathing.ensureRangeIsInRoom(origin.roomName, destination, options.range);
         if (origin.roomName !== destination.roomName && !options.allowedRooms) {
             const roomDistance = Game.map.getRoomLinearDistance(origin.roomName, destination.roomName);
-            if (roomDistance > 2) {
+            if (roomDistance >= 2) {
                 const route = this.findRoute(origin.roomName, destination.roomName, options);
                 if (route !== ERR_NO_PATH) {
                     options.allowedRooms = route;
@@ -417,7 +417,8 @@ export class Pathing {
                     return Infinity;
                 }
                 const isMyRoom = Game.rooms[roomName] && Game.rooms[roomName].controller && Game.rooms[roomName].controller.my;
-                if (isMyRoom) {
+                const isRemoteMiningRoom = Memory.remoteData[roomName];
+                if (isMyRoom || isRemoteMiningRoom) {
                     return 1;
                 }
                 if (options.preferHighway) {
@@ -426,6 +427,9 @@ export class Pathing {
                     if (isHighway) {
                         return 1;
                     }
+                }
+                if (isKeeperRoom(roomName)) {
+                    return 2;
                 }
                 return 1.5;
             },

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -1,4 +1,4 @@
-import { posFromMem } from '../modules/data';
+import { isKeeperRoom, posFromMem } from '../modules/data';
 
 //@ts-ignore
 global.IN_ROOM = -20;
@@ -320,24 +320,19 @@ export class Pathing {
                 }
 
                 matrix = matrix.clone();
-                if (options.avoidSourceKeepers) {
-                    if (
-                        Memory.remoteData[roomName]?.sourceKeeperLairs ||
-                        (!Memory.remoteData[roomName] && room.find(FIND_STRUCTURES).some((struct) => struct.structureType === STRUCTURE_KEEPER_LAIR))
-                    ) {
-                        room.find(FIND_HOSTILE_CREEPS, {
-                            filter: (creep) =>
-                                creep.owner.username === 'Source Keeper' &&
-                                (creep.getActiveBodyparts(ATTACK) > 0 || creep.getActiveBodyparts(RANGED_ATTACK) > 0),
-                        }).forEach((creep) => {
-                            const avoidArea = Pathing.getArea(creep.pos, 3);
-                            for (let x = avoidArea.left; x <= avoidArea.right; x++) {
-                                for (let y = avoidArea.top; y <= avoidArea.bottom; y++) {
-                                    matrix.set(x, y, 50);
-                                }
+                if (options.avoidSourceKeepers && isKeeperRoom(room.name)) {
+                    room.find(FIND_HOSTILE_CREEPS, {
+                        filter: (creep) =>
+                            creep.owner.username === 'Source Keeper' &&
+                            (creep.getActiveBodyparts(ATTACK) > 0 || creep.getActiveBodyparts(RANGED_ATTACK) > 0),
+                    }).forEach((creep) => {
+                        const avoidArea = Pathing.getArea(creep.pos, 3);
+                        for (let x = avoidArea.left; x <= avoidArea.right; x++) {
+                            for (let y = avoidArea.top; y <= avoidArea.bottom; y++) {
+                                matrix.set(x, y, 50);
                             }
-                        });
-                    }
+                        }
+                    });
                 }
 
                 if (options.exitCost) {

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -328,7 +328,7 @@ export class Pathing {
                             const avoidArea = Pathing.getArea(creep.pos, 3);
                             for (let x = avoidArea.left; x <= avoidArea.right; x++) {
                                 for (let y = avoidArea.top; y <= avoidArea.bottom; y++) {
-                                    matrix.set(x, y, 0xc8);
+                                    matrix.set(x, y, 50);
                                 }
                             }
                         });

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -329,7 +329,9 @@ export class Pathing {
                         const avoidArea = Pathing.getArea(creep.pos, 3);
                         for (let x = avoidArea.left; x <= avoidArea.right; x++) {
                             for (let y = avoidArea.top; y <= avoidArea.bottom; y++) {
-                                matrix.set(x, y, 50);
+                                if (x !== destination.x || y !== destination.y) {
+                                    matrix.set(x, y, 50);
+                                }
                             }
                         }
                     });
@@ -361,6 +363,7 @@ export class Pathing {
                 if (Memory.rooms[room.name]?.miningAssignments) {
                     Object.keys(room.memory.miningAssignments)
                         .map((pos) => posFromMem(pos))
+                        .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
                         });
@@ -369,6 +372,7 @@ export class Pathing {
                 if (Memory.rooms[room.name]?.mineralMiningAssignments) {
                     Object.keys(room.memory.mineralMiningAssignments)
                         .map((pos) => posFromMem(pos))
+                        .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
                         });
@@ -377,6 +381,7 @@ export class Pathing {
                 if (Memory.remoteData[room.name]?.miningPositions) {
                     Object.values(Memory.remoteData[room.name].miningPositions)
                         .map((pos) => posFromMem(pos))
+                        .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
                         });

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -317,7 +317,8 @@ export class PopulationManagement {
                 Memory.roomData[remoteRoom].roomStatus !== RoomMemoryStatus.OWNED_INVADER &&
                 Memory.remoteData[remoteRoom].threatLevel !== RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS &&
                 Memory.remoteData[remoteRoom].reservationState !== RemoteRoomReservationStatus.ENEMY &&
-                Memory.remoteData[remoteRoom].gatherer === AssignmentStatus.UNASSIGNED
+                (Memory.remoteData[remoteRoom].gatherer === AssignmentStatus.UNASSIGNED ||
+                    Memory.remoteData[remoteRoom].gathererSK === AssignmentStatus.UNASSIGNED)
         );
     }
 
@@ -340,7 +341,11 @@ export class PopulationManagement {
         let result = spawn.smartSpawn(PARTS, name, options);
 
         if (result === OK) {
-            Memory.remoteData[remoteRoomName].gatherer = name;
+            if (Memory.remoteData[remoteRoomName].gatherer === AssignmentStatus.UNASSIGNED) {
+                Memory.remoteData[remoteRoomName].gatherer = name;
+            } else {
+                Memory.remoteData[remoteRoomName].gathererSK = name;
+            }
         }
 
         return result;

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -37,6 +37,7 @@ const ROLE_TAG_MAP: { [key in Role]: string } = {
     [Role.UPGRADER]: 'u',
     [Role.REMOTE_MINER]: 'rm',
     [Role.KEEPER_EXTERMINATOR]: 'e',
+    [Role.REMOTE_MINERAL_MINER]: 'rmm',
 };
 
 export class PopulationManagement {
@@ -331,10 +332,6 @@ export class PopulationManagement {
             },
         };
 
-        if (isKeeperRoom(remoteRoomName) || isCenterRoom(remoteRoomName)) {
-            options.boosts = [BoostType.CARRY, BoostType.MOVE];
-        }
-
         let name = this.generateName(options.memory.role, spawn.name);
         let PARTS = PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9);
         PARTS.push(WORK, WORK, CARRY, CARRY, MOVE);
@@ -477,6 +474,84 @@ export class PopulationManagement {
                     // Do not allow nonBoosted TOUGH parts
                     needed.tough = 0;
                     return;
+                }
+                energyAvailable -= BODYPART_COST[part];
+                partsArray.push(part);
+            });
+        }
+
+        return partsArray;
+    }
+
+    /**
+     * Create a creep body with parts in the same ratio as provided in the parts Array except that it will only
+     */
+    public static createCreepBodyWithDynamicMove(room: Room, parts: BodyPartConstant[], partsCap: number = 50, opts?: SpawnOptions) {
+        const getSortValue = (part: BodyPartConstant): number => (part === MOVE ? 2 : part === CARRY ? 1 : 0);
+        parts = parts.sort((a, b) => getSortValue(b) - getSortValue(a));
+        let energyAvailable = room.energyCapacityAvailable;
+        let hasEnergyLeft = true;
+        let partsArray = [];
+        if (partsCap > 50) {
+            partsCap = 50;
+        }
+        const partRatio = {};
+        for (const part of parts) {
+            if (partRatio[part]) {
+                partRatio[part] += 1;
+            } else {
+                partRatio[part] = 1;
+            }
+        }
+
+        if (opts?.boosts) {
+            var boostMap = getResourceBoostsAvailable(room, Array.from(opts.boosts));
+        }
+
+        let move = 0;
+
+        while (hasEnergyLeft && partsArray.length < partsCap) {
+            if (partsCap - partsArray.length === 1 && move === 0) {
+                break;
+            }
+            parts.forEach((part) => {
+                if (partsArray.length === 50) {
+                    return;
+                }
+                if (energyAvailable < BODYPART_COST[part]) {
+                    hasEnergyLeft = false;
+                    return; // no more energy
+                }
+
+                if (part !== MOVE && move > -1) {
+                    return; // First add a MOVE part
+                }
+                if (part === MOVE && move < 0) {
+                    return; // Move not currently needed
+                }
+
+                if (part !== MOVE) {
+                    move++;
+                }
+
+                let boostFound = false;
+                if (opts?.boosts?.length) {
+                    opts.boosts
+                        .filter((boostType) => part === BODY_TO_BOOST_MAP[boostType])
+                        .forEach((boostType) => {
+                            const boostsAvailableCount = boostMap[boostType]?.map((boost) => boost.amount).reduce((sum, next) => sum + next) ?? 0;
+                            if (boostsAvailableCount) {
+                                const nextAvailableBoostResource = boostMap[boostType].filter((boost) => boost.amount > 0)[0].resource;
+                                boostMap[nextAvailableBoostResource] -= 1;
+                                const tierBoost =
+                                    nextAvailableBoostResource.length > 2 ? nextAvailableBoostResource.length - 1 : nextAvailableBoostResource.length;
+                                move -= this.getMove(part, tierBoost) * Math.ceil((parts.length - partRatio[MOVE]) / partRatio[MOVE]);
+                                boostFound = true;
+                            }
+                        });
+                }
+                if (!boostFound) {
+                    move -= this.getMove(part, 1) * Math.ceil((parts.length - partRatio[MOVE]) / partRatio[MOVE]);
                 }
                 energyAvailable -= BODYPART_COST[part];
                 partsArray.push(part);
@@ -826,6 +901,39 @@ export class PopulationManagement {
         let result = spawn.spawnMax([WORK, WORK, MOVE], name, options);
         if (result === OK) {
             spawn.room.memory.mineralMiningAssignments[nextAvailableAssignment] = name;
+        }
+        return result;
+    }
+
+    static findRemoteMineralMinerNeed(room: Room) {
+        if (room.storage?.store.getFreeCapacity() < 100000 || room.storage?.store[room.mineral.mineralType] > 100000) {
+            return false;
+        }
+
+        return room.memory.remoteMiningRooms.find(
+            (remoteRoom) =>
+                Memory.roomData[remoteRoom].roomStatus !== RoomMemoryStatus.OWNED_INVADER &&
+                Memory.remoteData[remoteRoom].threatLevel !== RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS &&
+                Memory.remoteData[remoteRoom].reservationState !== RemoteRoomReservationStatus.ENEMY &&
+                Memory.remoteData[remoteRoom].mineralAvailableAt <= Game.time &&
+                Memory.remoteData[remoteRoom].mineralMiner === AssignmentStatus.UNASSIGNED
+        );
+    }
+
+    static spawnRemoteMineralMiner(spawn: StructureSpawn, remoteRoomName: string): ScreepsReturnCode {
+        const options: SpawnOptions = {
+            memory: {
+                room: spawn.room.name,
+                role: Role.REMOTE_MINERAL_MINER,
+                currentTaskPriority: Priority.HIGH,
+                assignment: remoteRoomName,
+            },
+        };
+
+        const name = this.generateName(options.memory.role, spawn.name);
+        const result = spawn.spawnMax([WORK, WORK, CARRY, MOVE, MOVE], name, options);
+        if (result === OK) {
+            Memory.remoteData[remoteRoomName].mineralMiner = name;
         }
         return result;
     }

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -9,10 +9,11 @@ export function manageRemoteRoom(controllingRoomName: string, remoteRoomName: st
         Memory.remoteData[remoteRoomName].threatLevel = monitorThreatLevel(remoteRoom);
 
         const mineralAvailableAt = Memory.remoteData[remoteRoomName].mineralAvailableAt;
-        if (isKeeperRoom(remoteRoomName) && mineralAvailableAt === undefined) {
+        if ((isKeeperRoom(remoteRoomName) || isCenterRoom(remoteRoomName)) && mineralAvailableAt === undefined) {
             // TODO: delete after intial conversion
             Memory.remoteData[remoteRoomName].mineralMiner = AssignmentStatus.UNASSIGNED;
             Memory.remoteData[remoteRoomName].mineralAvailableAt = Game.time;
+            Memory.remoteData[remoteRoomName].miningPositions = createMiningPositionData(controllingRoomName, remoteRoomName);
         }
     }
 
@@ -175,6 +176,14 @@ function createMiningPositionData(controllingRoomName: string, remoteRoomName: s
     let miningPositions: { [id: Id<Source>]: string } = {};
 
     harvestTargets.forEach((target) => {
+        const path = PathFinder.search(getStoragePos(controllingRoom), { pos: target.pos, range: 1 });
+        if (!path.incomplete) {
+            miningPositions[target.id] = path.path.pop().toMemSafe();
+        }
+    });
+
+    const mineralTargets: Mineral[] = remoteRoom.find(FIND_MINERALS);
+    mineralTargets.forEach((target) => {
         const path = PathFinder.search(getStoragePos(controllingRoom), { pos: target.pos, range: 1 });
         if (!path.incomplete) {
             miningPositions[target.id] = path.path.pop().toMemSafe();

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -1,5 +1,5 @@
 import { CombatIntel } from './combatIntel';
-import { isCenterRoom, isKeeperRoom as isKeeperRoom, posFromMem } from './data';
+import { isCenterRoom, isKeeperRoom as isKeeperRoom } from './data';
 import { PopulationManagement } from './populationManagement';
 import { getStoragePos } from './roomDesign';
 
@@ -7,6 +7,13 @@ export function manageRemoteRoom(controllingRoomName: string, remoteRoomName: st
     let remoteRoom = Game.rooms[remoteRoomName];
     if (remoteRoom) {
         Memory.remoteData[remoteRoomName].threatLevel = monitorThreatLevel(remoteRoom);
+
+        const mineralAvailableAt = Memory.remoteData[remoteRoomName].mineralAvailableAt;
+        if (isKeeperRoom(remoteRoomName) && mineralAvailableAt === undefined) {
+            // TODO: delete after intial conversion
+            Memory.remoteData[remoteRoomName].mineralMiner = AssignmentStatus.UNASSIGNED;
+            Memory.remoteData[remoteRoomName].mineralAvailableAt = Game.time;
+        }
     }
 
     const threatLevel = Memory.remoteData[remoteRoomName].threatLevel;
@@ -147,10 +154,14 @@ export function addRemoteRoom(controllingRoomName: string, remoteRoomName: strin
     if (isKeeperRoom(remoteRoomName)) {
         remoteData.keeperExterminator = AssignmentStatus.UNASSIGNED;
         remoteData.sourceKeeperLairs = createKeeperLairData(remoteRoomName);
-        remoteData.gathererSK = AssignmentStatus.UNASSIGNED;
     } else if (!isCenterRoom(remoteRoomName)) {
         remoteData.reservationState = RemoteRoomReservationStatus.LOW;
         remoteData.reserver = AssignmentStatus.UNASSIGNED;
+    }
+    if (isKeeperRoom(remoteRoomName) || isCenterRoom(remoteRoomName)) {
+        remoteData.gathererSK = AssignmentStatus.UNASSIGNED;
+        remoteData.mineralMiner = AssignmentStatus.UNASSIGNED;
+        remoteData.mineralAvailableAt = Game.time;
     }
 
     Memory.remoteData[remoteRoomName] = remoteData;

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -111,7 +111,7 @@ export function findMiningPositions(controllingRoomName: string, remoteRoomName:
     return miningPositions;
 }
 
-export function findSourceKeeperPositions(remoteRoomName: string): { [id: Id<Structure<StructureConstant>>]: Id<Source> } {
+export function findKeeperLairs(remoteRoomName: string): { [id: Id<Source> | Id<Mineral>]: Id<StructureKeeperLair> } {
     const lairs = {};
     Game.rooms[remoteRoomName]
         .find(FIND_HOSTILE_STRUCTURES, {
@@ -119,7 +119,7 @@ export function findSourceKeeperPositions(remoteRoomName: string): { [id: Id<Str
         })
         .forEach((lair) => {
             const source = lair.pos.findClosestByRange(FIND_SOURCES);
-            if (lair.pos.getRangeTo(source) < 5) {
+            if (lair.pos.getRangeTo(source) < 6) {
                 lairs[source.id] = lair.id;
             } else {
                 const mineral = lair.pos.findClosestByRange(FIND_MINERALS);
@@ -182,7 +182,7 @@ export function addRemoteRoom(controllingRoomName: string, remoteRoomName: strin
 
     if (isKeeperRoom(remoteRoomName)) {
         remoteData.keeperExterminator = AssignmentStatus.UNASSIGNED;
-        remoteData.sourceKeeperLairs = findSourceKeeperPositions(remoteRoomName);
+        remoteData.sourceKeeperLairs = findKeeperLairs(remoteRoomName);
         remoteData.gathererSK = AssignmentStatus.UNASSIGNED;
     } else if (!isCenterRoom(remoteRoomName)) {
         remoteData.reservationState = RemoteRoomReservationStatus.LOW;
@@ -284,7 +284,7 @@ export function convertOldMemoryToNew(controllingRoomName: string, remoteRoomNam
         Memory.remoteData[remoteRoomName].miningPositions = findMiningPositions(controllingRoomName, remoteRoomName);
     }
     if (!Memory.remoteData[remoteRoomName].sourceKeeperLairs) {
-        Memory.remoteData[remoteRoomName].sourceKeeperLairs = findSourceKeeperPositions(remoteRoomName);
+        Memory.remoteData[remoteRoomName].sourceKeeperLairs = findKeeperLairs(remoteRoomName);
     }
     if (isKeeperRoom(remoteRoomName) && Memory.remoteData[remoteRoomName].gathererSK === undefined) {
         Memory.remoteData[remoteRoomName].gathererSK = AssignmentStatus.UNASSIGNED;

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -183,6 +183,7 @@ export function addRemoteRoom(controllingRoomName: string, remoteRoomName: strin
     if (isKeeperRoom(remoteRoomName)) {
         remoteData.keeperExterminator = AssignmentStatus.UNASSIGNED;
         remoteData.sourceKeeperLairs = findSourceKeeperPositions(remoteRoomName);
+        remoteData.gathererSK = AssignmentStatus.UNASSIGNED;
     } else if (!isCenterRoom(remoteRoomName)) {
         remoteData.reservationState = RemoteRoomReservationStatus.LOW;
         remoteData.reserver = AssignmentStatus.UNASSIGNED;
@@ -284,5 +285,8 @@ export function convertOldMemoryToNew(controllingRoomName: string, remoteRoomNam
     }
     if (!Memory.remoteData[remoteRoomName].sourceKeeperLairs) {
         Memory.remoteData[remoteRoomName].sourceKeeperLairs = findSourceKeeperPositions(remoteRoomName);
+    }
+    if (isKeeperRoom(remoteRoomName) && Memory.remoteData[remoteRoomName].gathererSK === undefined) {
+        Memory.remoteData[remoteRoomName].gathererSK = AssignmentStatus.UNASSIGNED;
     }
 }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -448,6 +448,12 @@ function runSpawning(room: Room) {
                 let spawn = availableSpawns.pop();
                 spawn?.spawnGatherer(gathererNeed);
             }
+
+            const remoteMineralMinerNeed = PopulationManagement.findRemoteMineralMinerNeed(room);
+            if (remoteMineralMinerNeed) {
+                const spawn = availableSpawns.pop();
+                spawn?.spawnRemoteMineralMiner(remoteMineralMinerNeed);
+            }
         }
     }
 

--- a/src/modules/squadManagement.ts
+++ b/src/modules/squadManagement.ts
@@ -1,4 +1,3 @@
-import { isThisTypeNode, updateFor } from 'typescript';
 import { CombatCreep } from '../virtualCreeps/combatCreep';
 import { posFromMem } from './data';
 import { Pathing } from './pathing';
@@ -343,7 +342,7 @@ export class SquadManagement {
                 const target = this.findPathingTarget();
                 if (target instanceof Creep) {
                     this.squadLeader.travelTo(target, { range: range, maxRooms: 1 });
-                } else {
+                } else if (target) {
                     this.squadLeader.travelTo(target, {
                         range: 1,
                         ignoreStructures: true,

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -65,11 +65,15 @@ Object.defineProperty(Room.prototype, 'mineral', {
 
 Object.defineProperty(Room.prototype, 'managerLink', {
     get: function (this: Room) {
+        if (this.memory.managerLink) {
+            return Game.getObjectById(this.memory.managerLink);
+        }
         let posToCheck = posFromMem(this.memory.anchorPoint || this.memory.managerPos);
         let link = posToCheck
             ?.findInRange(FIND_MY_STRUCTURES, 1)
             .filter((structure) => structure.structureType === STRUCTURE_LINK)
             .pop();
+        this.memory.managerLink = link.id;
         return link;
     },
     enumerable: false,

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -73,7 +73,7 @@ Object.defineProperty(Room.prototype, 'managerLink', {
             ?.findInRange(FIND_MY_STRUCTURES, 1)
             .filter((structure) => structure.structureType === STRUCTURE_LINK)
             .pop();
-        this.memory.managerLink = link.id;
+        this.memory.managerLink = link?.id;
         return link;
     },
     enumerable: false,

--- a/src/prototypes/structureSpawn.ts
+++ b/src/prototypes/structureSpawn.ts
@@ -51,3 +51,7 @@ StructureSpawn.prototype.spawnMineralMiner = function () {
 StructureSpawn.prototype.spawnKeeperExterminator = function (remoteRoomName: string) {
     return PopulationManagement.spawnKeeperExterminator(this, remoteRoomName);
 };
+
+StructureSpawn.prototype.spawnRemoteMineralMiner = function (remoteRoomName: string) {
+    return PopulationManagement.spawnRemoteMineralMiner(this, remoteRoomName);
+};

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -199,4 +199,8 @@ export class Gatherer extends TransportCreep {
             this.repair(road);
         }
     }
+
+    protected damaged(): boolean {
+        return this.hits < this.hitsMax * 0.85;
+    }
 }

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -1,4 +1,4 @@
-import { getUsername } from '../modules/data';
+import { getUsername, isKeeperRoom } from '../modules/data';
 import { posFromMem } from '../modules/data';
 import { Pathing } from '../modules/pathing';
 import { getStructureForPos, posInsideBunker } from '../modules/roomDesign';
@@ -7,6 +7,7 @@ import { TransportCreep } from '../virtualCreeps/transportCreep';
 export class Gatherer extends TransportCreep {
     protected run() {
         if (this.damaged() || Memory.remoteData[this.memory.assignment]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
+            delete this.memory.targetId;
             this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
             return;
         }
@@ -117,22 +118,28 @@ export class Gatherer extends TransportCreep {
         );
     }
 
-    protected findCollectionTarget(roomName?: string): Id<Resource> | Id<Structure> {
-        let miningPositions = Memory.remoteData[roomName].miningPositions;
+    protected findCollectionTarget(roomName?: string): Id<Resource> | Id<Structure> | Id<Tombstone> {
+        const miningPositions = Memory.remoteData[roomName].miningPositions;
 
-        let targets: { id: Id<Resource> | Id<Structure>; amount: number; shouldBuildRoad?: boolean }[] = [];
+        const targets: { id: Id<Resource> | Id<Structure> | Id<Tombstone>; amount: number; shouldBuildRoad?: boolean }[] = [];
 
         Object.values(miningPositions).forEach((posString) => {
             let pos = posFromMem(posString);
             const areaInRange = Pathing.getArea(pos, 3);
-            let lookArea = this.room.lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true);
+            let lookArea = Game.rooms[roomName].lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true);
             if (lookArea.some((look) => look.creep?.owner?.username === 'Source Keeper')) {
                 return;
             }
 
             lookArea
-                .filter((look) => look.resource?.resourceType === RESOURCE_ENERGY)
-                .forEach((resource) => targets.push({ id: resource.resource.id, amount: resource.resource.amount, shouldBuildRoad: false }));
+                .filter((look) => look.resource?.resourceType === RESOURCE_ENERGY || look.tombstone?.store.energy)
+                .forEach((look) => {
+                    if (look.resource) {
+                        targets.push({ id: look.resource.id, amount: look.resource.amount, shouldBuildRoad: false });
+                    } else {
+                        targets.push({ id: look.tombstone.id, amount: look.tombstone.store?.energy, shouldBuildRoad: false });
+                    }
+                });
 
             let container: StructureContainer = pos
                 .lookFor(LOOK_STRUCTURES)
@@ -142,11 +149,47 @@ export class Gatherer extends TransportCreep {
             }
         });
 
-        const selectedTarget = targets.length ? targets.reduce((highest, next) => (highest.amount > next.amount ? highest : next)) : undefined;
+        // Ensure that if there are 2 gatherers they do not go toward same target
+        const isMainGatherer = this.name === Memory.remoteData[roomName].gatherer;
+        const secondGatherer = isMainGatherer ? Memory.remoteData[roomName].gathererSK : Memory.remoteData[roomName].gatherer;
+        let excludeTargetId: string;
+        if (secondGatherer && secondGatherer !== AssignmentStatus.UNASSIGNED) {
+            excludeTargetId = Game.creeps[secondGatherer]?.memory?.targetId;
+            // Main gatherer always has first dibs on targets (this prevents same target allocation when both gatherers look for a target at the same time)
+            if (!isMainGatherer && Game.creeps[secondGatherer] && !excludeTargetId) {
+                return undefined;
+            }
+        }
+
+        // If there are no more targets check for any loose resources (creeps that died on the way or at mineral)
+        if (!targets.length) {
+            const resources = Game.rooms[roomName].find(FIND_DROPPED_RESOURCES);
+            resources.forEach((resource) => targets.push({ id: resource.id, amount: resource.amount, shouldBuildRoad: false }));
+        }
+
+        // Get highest target unless a target is close by then pick that up first
+        let selectedTarget: { id: Id<Resource> | Id<Structure> | Id<Tombstone>; amount: number; shouldBuildRoad?: boolean } = {
+            id: undefined,
+            amount: 0,
+            shouldBuildRoad: false,
+        };
+        targets
+            .filter((target) => target.id !== excludeTargetId)
+            .every((target) => {
+                if (this.pos.roomName === this.memory.assignment && this.pos.getRangeTo(Game.getObjectById(target.id)) <= 3) {
+                    selectedTarget = target;
+                    return false;
+                }
+                if (selectedTarget.amount < target.amount) {
+                    selectedTarget = target;
+                }
+                return true;
+            });
 
         if (selectedTarget?.shouldBuildRoad === false) {
             this.memory.shouldBuildRoad = false;
         }
+
         return selectedTarget?.id;
     }
 

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -122,7 +122,7 @@ export class Gatherer extends TransportCreep {
 
         let targets: { id: Id<Resource> | Id<Structure>; amount: number; shouldBuildRoad?: boolean }[] = [];
 
-        miningPositions.forEach((posString) => {
+        Object.values(miningPositions).forEach((posString) => {
             let pos = posFromMem(posString);
             const areaInRange = Pathing.getArea(pos, 3);
             let lookArea = this.room.lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true);

--- a/src/roles/keeperExterminator.ts
+++ b/src/roles/keeperExterminator.ts
@@ -22,8 +22,8 @@ export class KeeperExterminator extends CombatCreep {
                     const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
                         ([sourceId, miningPos]) => target.pos.toMemSafe() === miningPos
                     );
-                    const lair = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[sourceId[0]] as Id<Structure<StructureConstant>>;
-                    this.travelTo(Game.getObjectById(lair), { range: 1 });
+                    const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[sourceId[0]] as Id<Structure<StructureConstant>>;
+                    this.travelTo(Game.getObjectById(lairId), { range: 1, avoidSourceKeepers: false });
                 }
             } else if (target instanceof Structure) {
                 if (!this.pos.isNearTo(target)) {

--- a/src/roles/keeperExterminator.ts
+++ b/src/roles/keeperExterminator.ts
@@ -19,10 +19,11 @@ export class KeeperExterminator extends CombatCreep {
                 } else if (miner?.memory.destination !== target.pos.toMemSafe() || !miner?.pos.isNearTo(target.pos)) {
                     this.travelTo(target.pos, { avoidSourceKeepers: false });
                 } else {
-                    this.travelTo(
-                        target.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_KEEPER_LAIR }),
-                        { range: 1 }
+                    const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
+                        ([sourceId, miningPos]) => target.pos.toMemSafe() === miningPos
                     );
+                    const lair = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[sourceId[0]] as Id<Structure<StructureConstant>>;
+                    this.travelTo(Game.getObjectById(lair), { range: 1 });
                 }
             } else if (target instanceof Structure) {
                 if (!this.pos.isNearTo(target)) {
@@ -74,9 +75,9 @@ export class KeeperExterminator extends CombatCreep {
             return this.pos.findClosestByPath(keepers)?.id;
         }
 
-        let lairs = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_STRUCTURES, {
-            filter: (s) => s.structureType === STRUCTURE_KEEPER_LAIR,
-        }) as StructureKeeperLair[];
+        let lairs = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) =>
+            Game.getObjectById(lairId)
+        ) as StructureKeeperLair[];
         let nextSpawn = lairs?.reduce((lowestTimer, next) => (lowestTimer.ticksToSpawn <= next.ticksToSpawn ? lowestTimer : next));
         if (nextSpawn) {
             return nextSpawn.id;

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -10,8 +10,9 @@ export class RemoteMiner extends WaveCreep {
 
         //if we have visibility in assigned room
         if (Game.rooms[this.memory.assignment]) {
+            const isAKeeperRoom = isKeeperRoom(this.memory.assignment);
             if (!this.memory.destination) {
-                this.memory.destination = this.findNextMiningPos();
+                this.memory.destination = this.findNextMiningPos(isAKeeperRoom);
             }
 
             let targetPos = posFromMem(this.memory.destination);
@@ -36,22 +37,27 @@ export class RemoteMiner extends WaveCreep {
                     } else if (container?.store.getFreeCapacity() === 0) {
                         delete this.memory.destination;
                     } else {
-                        let source = this.pos.findInRange(FIND_SOURCES_ACTIVE, 1).shift();
-                        if (source) {
-                            this.harvest(source);
+                        const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
+                            ([sourceId, miningPos]) => this.memory.destination === miningPos
+                        )?.[0];
+                        if (sourceId) {
+                            this.harvest(Game.getObjectById(sourceId));
                         } else {
                             delete this.memory.destination;
                         }
                     }
 
-                    if (isKeeperRoom(this.memory.assignment) && container && this.destinationSpawningKeeper()) {
+                    if (isAKeeperRoom && container && this.destinationSpawningKeeper()) {
                         this.say('🚨KEEPER🚨');
                         delete this.memory.destination;
                     }
                 }
-            } else if (isKeeperRoom(this.memory.assignment)) {
+            } else if (isAKeeperRoom) {
                 //travel out of danger-zone
-                this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
+                const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
+                    return { pos: Game.getObjectById(lairId).pos, range: 0 };
+                });
+                this.travelTo(lairPositions.pop(), { range: 7, flee: true, goals: lairPositions }); // Travel back to home room
             } else {
                 this.say('🚚 is SLOW!');
             }
@@ -60,35 +66,49 @@ export class RemoteMiner extends WaveCreep {
         }
     }
 
-    private findNextMiningPos(): string {
-        let nextPos = Memory.remoteData[this.memory.assignment]?.miningPositions?.find((posString) => {
-            let pos = posFromMem(posString);
-            let hasKeeper = !!pos.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
-            let lair = pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
-                filter: (s) => s.structureType === STRUCTURE_KEEPER_LAIR,
-            }) as StructureKeeperLair;
-            let keeperSpawning = lair?.ticksToSpawn < 100;
+    private findNextMiningPos(isKeeperRoom: boolean): string {
+        const nextPos = Object.entries(Memory.remoteData[this.memory.assignment]?.miningPositions)?.find(([sourceId, miningPosString]) => {
+            const pos = posFromMem(miningPosString);
+            if (isKeeperRoom) {
+                // LAIR
+                const lairId = Memory.remoteData[this.memory.assignment]?.sourceKeeperLairs[sourceId];
+                const lair = Game.getObjectById(lairId[1]) as StructureKeeperLair;
+                const keeperSpawning = lair?.ticksToSpawn < 100;
+                if (keeperSpawning) {
+                    return false;
+                }
 
-            if (hasKeeper || keeperSpawning) {
+                // KEEPER
+                const hasKeeper = !!pos.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
+                if (hasKeeper) {
+                    return false;
+                }
+            }
+
+            // ACTIVE SOURCE
+            const source = Game.getObjectById(sourceId) as Source;
+            if (!source.energy) {
                 return false;
             }
 
-            let source = pos.findInRange(FIND_SOURCES_ACTIVE, 1).shift();
-            let container: StructureContainer = pos
+            // CONTAINER NOT FILLED
+            const container: StructureContainer = pos
                 .lookFor(LOOK_STRUCTURES)
                 .find((s) => s.structureType === STRUCTURE_CONTAINER) as StructureContainer;
 
-            return !!source && !(container?.store.getFreeCapacity() === 0);
+            return !(container?.store.getFreeCapacity() === 0);
         });
-
-        return nextPos;
+        if (!nextPos) {
+            return undefined;
+        }
+        return nextPos[1];
     }
 
     private destinationSpawningKeeper(): boolean {
-        let pos = posFromMem(this.memory.destination);
-        let lair = pos?.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
-            filter: (s) => s.structureType === STRUCTURE_KEEPER_LAIR,
-        }) as StructureKeeperLair;
-        return lair?.ticksToSpawn < 20;
+        const lair = Object.entries(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).find(
+            ([sourceId, lairId]) => this.pos.getRangeTo(Game.getObjectById(sourceId)) <= 5
+        );
+        const lairInRange = Game.getObjectById(lair[1]) as StructureKeeperLair;
+        return lairInRange?.ticksToSpawn < 20;
     }
 }

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -37,11 +37,9 @@ export class RemoteMiner extends WaveCreep {
                     } else if (container?.store.getFreeCapacity() === 0) {
                         delete this.memory.destination;
                     } else {
-                        const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-                            ([sourceId, miningPos]) => this.memory.destination === miningPos
-                        )?.[0];
-                        if (sourceId) {
-                            this.harvest(Game.getObjectById(sourceId));
+                        const source = Game.getObjectById(this.getSourceIdByMiningPos(this.memory.destination)) as Source;
+                        if (source && source.energy) {
+                            this.harvest(source);
                         } else {
                             delete this.memory.destination;
                         }
@@ -72,7 +70,7 @@ export class RemoteMiner extends WaveCreep {
             if (isKeeperRoom) {
                 // LAIR
                 const lairId = Memory.remoteData[this.memory.assignment]?.sourceKeeperLairs[sourceId];
-                const lair = Game.getObjectById(lairId[1]) as StructureKeeperLair;
+                const lair = Game.getObjectById(lairId) as StructureKeeperLair;
                 const keeperSpawning = lair?.ticksToSpawn < 100;
                 if (keeperSpawning) {
                     return false;
@@ -105,10 +103,14 @@ export class RemoteMiner extends WaveCreep {
     }
 
     private destinationSpawningKeeper(): boolean {
-        const lair = Object.entries(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).find(
-            ([sourceId, lairId]) => this.pos.getRangeTo(Game.getObjectById(sourceId)) <= 5
-        );
-        const lairInRange = Game.getObjectById(lair[1]) as StructureKeeperLair;
+        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceIdByMiningPos(this.memory.destination)];
+        const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
         return lairInRange?.ticksToSpawn < 20;
+    }
+
+    private getSourceIdByMiningPos(pos: string): Id<Source> {
+        return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
+            ([sourceId, miningPos]) => this.memory.destination === miningPos
+        )?.[0] as Id<Source>;
     }
 }

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -45,7 +45,7 @@ export class RemoteMiner extends WaveCreep {
                         }
                     }
 
-                    if (isAKeeperRoom && container && this.destinationSpawningKeeper()) {
+                    if (isAKeeperRoom && container && this.destinationSpawningKeeper(this.memory.destination)) {
                         this.say('🚨KEEPER🚨');
                         delete this.memory.destination;
                     }
@@ -102,15 +102,15 @@ export class RemoteMiner extends WaveCreep {
         return nextPos[1];
     }
 
-    private destinationSpawningKeeper(): boolean {
-        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceIdByMiningPos(this.memory.destination)];
+    private destinationSpawningKeeper(pos: string): boolean {
+        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceIdByMiningPos(pos)];
         const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
         return lairInRange?.ticksToSpawn < 20;
     }
 
     private getSourceIdByMiningPos(pos: string): Id<Source> {
         return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-            ([sourceId, miningPos]) => this.memory.destination === miningPos
+            ([sourceId, miningPos]) => pos === miningPos
         )?.[0] as Id<Source>;
     }
 }

--- a/src/roles/remoteMineralMiner.ts
+++ b/src/roles/remoteMineralMiner.ts
@@ -1,0 +1,80 @@
+import { WaveCreep } from '../virtualCreeps/waveCreep';
+
+export class RemoteMineralMiner extends WaveCreep {
+    protected run() {
+        if (this.damaged() || Memory.remoteData[this.memory.assignment]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
+            this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
+            return;
+        }
+
+        let target: any = Game.getObjectById(this.memory.targetId);
+        if (!target) {
+            if (Game.rooms[this.memory.assignment] || this.travelToRoom(this.memory.assignment) === IN_ROOM) {
+                // Find target is visibility exists
+                this.memory.targetId = this.findTarget();
+                target = Game.getObjectById(this.memory.targetId);
+            }
+        }
+        if (target) {
+            this.memory.currentTaskPriority = Priority.HIGH;
+            if (target.structureType === 'spawn') {
+                if (this.pos.isNearTo(target)) {
+                    target.recycleCreep(this);
+                }
+                this.travelTo(target, { range: 1 });
+            } else if (this.store.getFreeCapacity() >= this.getActiveBodyparts(WORK)) {
+                if (this.pos.getRangeTo(target) < 9 && (this.hasKeeper(target) || this.destinationSpawningKeeper())) {
+                    this.say('🚨KEEPER🚨');
+                    this.memory.destination = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[target.id];
+                } else {
+                    delete this.memory.destination;
+                }
+
+                if (this.memory.destination) {
+                    const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
+                        return { pos: Game.getObjectById(lairId).pos, range: 0 };
+                    });
+                    this.travelTo(Game.getObjectById(this.memory.destination), {
+                        range: 7,
+                        flee: true,
+                        goals: lairPositions,
+                        avoidSourceKeepers: false,
+                    }); // Travel back to home room
+                    return;
+                }
+
+                if (!this.memory.destination) {
+                    const result = this.harvest(target);
+                    if (result === ERR_NOT_IN_RANGE) {
+                        this.travelTo(target, { maxOps: 20000, avoidHostileRooms: true, range: 1 });
+                    } else if (result === ERR_NOT_ENOUGH_RESOURCES) {
+                        Memory.remoteData[this.memory.assignment].mineralAvailableAt = Game.time + target.ticksToRegeneration;
+                        this.suicide();
+                    }
+                }
+            } else {
+                this.storeCargo();
+                // recycle
+                if (!this.memory.targetId && this.ticksToLive < 200) {
+                    this.memory.targetId = this.room.find(FIND_MY_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_SPAWN })[0].id;
+                }
+            }
+        }
+    }
+
+    private findTarget(): Id<Mineral> {
+        return Object.keys(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).find(
+            (sourceId) => Game.getObjectById(sourceId) instanceof Mineral
+        ) as Id<Mineral>;
+    }
+
+    private destinationSpawningKeeper(): boolean {
+        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.memory.targetId];
+        const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
+        return lairInRange?.ticksToSpawn < 16;
+    }
+
+    private hasKeeper(target: any): boolean {
+        return !!target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
+    }
+}

--- a/src/roles/remoteMineralMiner.ts
+++ b/src/roles/remoteMineralMiner.ts
@@ -1,3 +1,4 @@
+import { isKeeperRoom, posFromMem } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class RemoteMineralMiner extends WaveCreep {
@@ -7,74 +8,82 @@ export class RemoteMineralMiner extends WaveCreep {
             return;
         }
 
-        let target: any = Game.getObjectById(this.memory.targetId);
-        if (!target) {
-            if (Game.rooms[this.memory.assignment] || this.travelToRoom(this.memory.assignment) === IN_ROOM) {
-                // Find target is visibility exists
-                this.memory.targetId = this.findTarget();
-                target = Game.getObjectById(this.memory.targetId);
+        //if we have visibility in assigned room
+        if (Game.rooms[this.memory.assignment]) {
+            const isAKeeperRoom = isKeeperRoom(this.memory.assignment);
+            if (!this.memory.destination) {
+                this.memory.destination = this.findTarget();
             }
-        }
-        if (target) {
-            this.memory.currentTaskPriority = Priority.HIGH;
-            if (target.structureType === 'spawn') {
-                if (this.pos.isNearTo(target)) {
-                    target.recycleCreep(this);
-                }
-                this.travelTo(target, { range: 1 });
-            } else if (this.store.getFreeCapacity() >= this.getActiveBodyparts(WORK)) {
-                if (this.pos.getRangeTo(target) < 9 && (this.hasKeeper(target) || this.destinationSpawningKeeper())) {
-                    this.say('🚨KEEPER🚨');
-                    this.memory.destination = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[target.id];
-                } else {
-                    delete this.memory.destination;
-                }
 
-                if (this.memory.destination) {
-                    const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
-                        return { pos: Game.getObjectById(lairId).pos, range: 0 };
-                    });
-                    this.travelTo(Game.getObjectById(this.memory.destination), {
-                        range: 7,
-                        flee: true,
-                        goals: lairPositions,
-                        avoidSourceKeepers: false,
-                    }); // Travel back to home room
-                    return;
-                }
+            let targetPos = posFromMem(this.memory.destination);
+            if (targetPos) {
+                if (!this.pos.isEqualTo(targetPos)) {
+                    if (isAKeeperRoom && this.pos.getRangeTo(targetPos) < 9 && (this.hasKeeper(targetPos) || this.destinationSpawningKeeper())) {
+                        this.say('🚨KEEPER🚨');
+                        delete this.memory.destination;
+                        return;
+                    }
+                    this.travelTo(targetPos);
+                } else if (this.store.getFreeCapacity() >= this.getActiveBodyparts(WORK)) {
+                    if (isAKeeperRoom && (this.hasKeeper(targetPos) || this.destinationSpawningKeeper())) {
+                        this.say('🚨KEEPER🚨');
+                        delete this.memory.destination;
+                        return;
+                    }
+                    const mineral = Game.getObjectById(this.getMineralIdByMiningPos(this.memory.destination)) as Mineral;
+                    const result = this.harvest(mineral);
 
-                if (!this.memory.destination) {
-                    const result = this.harvest(target);
-                    if (result === ERR_NOT_IN_RANGE) {
-                        this.travelTo(target, { maxOps: 20000, avoidHostileRooms: true, range: 1 });
-                    } else if (result === ERR_NOT_ENOUGH_RESOURCES) {
-                        Memory.remoteData[this.memory.assignment].mineralAvailableAt = Game.time + target.ticksToRegeneration;
+                    // Finished mining mineral
+                    if (result === ERR_NOT_ENOUGH_RESOURCES) {
+                        Memory.remoteData[this.memory.assignment].mineralAvailableAt = Game.time + mineral.ticksToRegeneration;
                         this.suicide();
                     }
+                } else {
+                    this.storeCargo();
+                    if (this.ticksToLive < 200) {
+                        this.suicide(); // Can be changed to recycle once implemented
+                    }
                 }
-            } else {
-                this.storeCargo();
-                // recycle
-                if (!this.memory.targetId && this.ticksToLive < 200) {
-                    this.memory.targetId = this.room.find(FIND_MY_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_SPAWN })[0].id;
-                }
+            } else if (isAKeeperRoom) {
+                //travel out of danger-zone
+                const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
+                    return { pos: Game.getObjectById(lairId).pos, range: 0 };
+                });
+                this.travelTo(lairPositions.pop(), { range: 7, flee: true, goals: lairPositions }); // Travel back to home room
             }
+        } else {
+            this.travelToRoom(this.memory.assignment);
         }
     }
 
-    private findTarget(): Id<Mineral> {
-        return Object.keys(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).find(
-            (sourceId) => Game.getObjectById(sourceId) instanceof Mineral
-        ) as Id<Mineral>;
+    private findTarget(): string {
+        const nextPos = Object.entries(Memory.remoteData[this.memory.assignment]?.miningPositions)?.find(([sourceId, miningPosString]) => {
+            // ACTIVE SOURCE
+            const source = Game.getObjectById(sourceId) as Mineral;
+            if (!source.mineralType) {
+                return false;
+            }
+            return true;
+        });
+        if (!nextPos) {
+            return undefined;
+        }
+        return nextPos[1];
+    }
+
+    private getMineralIdByMiningPos(pos: string): Id<Mineral> {
+        return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
+            ([sourceId, miningPos]) => this.memory.destination === miningPos
+        )?.[0] as Id<Mineral>;
     }
 
     private destinationSpawningKeeper(): boolean {
-        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.memory.targetId];
+        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getMineralIdByMiningPos(this.memory.destination)];
         const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
         return lairInRange?.ticksToSpawn < 16;
     }
 
-    private hasKeeper(target: any): boolean {
-        return !!target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
+    private hasKeeper(target: RoomPosition): boolean {
+        return !!target.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
     }
 }

--- a/src/roles/squadAttacker.ts
+++ b/src/roles/squadAttacker.ts
@@ -91,7 +91,7 @@ export class SquadAttacker extends CombatCreep {
             }
 
             if (!target) {
-                target = this.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+                target = this.pos.findClosestByRange(FIND_HOSTILE_CREEPS, { filter: (c) => c.owner.username !== 'Source Keeper' });
             }
             if (!target) {
                 target = this.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -1,7 +1,7 @@
 import { WaveCreep } from './waveCreep';
 
 export class TransportCreep extends WaveCreep {
-    private previousTargetId: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin>;
+    private previousTargetId: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> | Id<Mineral>;
     protected incomingResourceAmount: number = 0;
     protected actionTaken: boolean = false;
     protected run() {


### PR DESCRIPTION
So there might be some controversial changes in this one so please do check and if we do merge, then check cpu usage afterwards.

Changes:

- Pathing now allows multiple goals (used to flee from multiple roomPositions on miner but can be used for combat later on as well)
- Storing MiningLink/SourceKeeperLairs/Remote sources and materials in memory to save cpu
- Only execute certain findTarget logik if it is an SK room
- reduced avoidSK room costMatrix to 50 instead of 200 (hopefully fixes rare pathing issue)
- convertMemory Method (call in remoteRoom can be removed after merge as that will be done in addRemoteRoom for new rooms)
- Only checking for hostileStructure every 3 ticks (just a random number but figured that does not need to run every tick)