### PR TITLE
Add wide-area scanning, power processing, and disable notifications on structures & creeps

### DIFF
--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -20,6 +20,7 @@ interface RoomMemory {
     dontCheckConstructionsBefore?: number;
     shipments?: Shipment[];
     factoryTask?: FactoryTask;
+    scanProgress?: string;
 }
 
 interface RemoteData {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -74,6 +74,7 @@ interface Room {
     addShipment(destination: string, resource: ResourceConstant, amount: number, marketOrderId?: string): ScreepsReturnCode;
     addFactoryTask(product: ResourceConstant, amount: number): ScreepsReturnCode;
     factory: StructureFactory;
+    observer: StructureObserver;
 }
 
 interface RoomPosition {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -76,6 +76,7 @@ interface Room {
     addFactoryTask(product: ResourceConstant, amount: number): ScreepsReturnCode;
     factory: StructureFactory;
     observer: StructureObserver;
+    powerSpawn: StructurePowerSpawn;
 }
 
 interface RoomPosition {

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ module.exports.loop = function () {
         console.log(cpuUsageString + `total: ${Game.cpu.getUsed().toFixed(2)}`);
     }
 
-    if (Game.shard.name !== 'shard3' && Game.cpu.bucket === 10000) {
+    if (Game.cpu.bucket === 10000) {
         Game.cpu.generatePixel();
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,13 @@ import { WaveCreep } from './virtualCreeps/waveCreep';
 require('./prototypes/requirePrototypes');
 
 module.exports.loop = function () {
+    //disable email notifications for non-spawn structures
+    Object.values(Game.structures)
+        .filter((struct) => struct.structureType !== STRUCTURE_SPAWN)
+        .forEach((struct) => {
+            struct.notifyWhenAttacked(false);
+        });
+
     let cpuUsed = 0;
     let cpuUsageString = `${Game.time}:   `;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,6 @@ import { WaveCreep } from './virtualCreeps/waveCreep';
 require('./prototypes/requirePrototypes');
 
 module.exports.loop = function () {
-    //disable email notifications for non-spawn structures
-    Object.values(Game.structures)
-        .filter((struct) => struct.structureType !== STRUCTURE_SPAWN)
-        .forEach((struct) => {
-            struct.notifyWhenAttacked(false);
-        });
-
     let cpuUsed = 0;
     let cpuUsageString = `${Game.time}:   `;
 

--- a/src/modules/data.ts
+++ b/src/modules/data.ts
@@ -43,16 +43,14 @@ export function updateRoomData(room: Room) {
         } else {
             data.roomStatus = RoomMemoryStatus.RESERVED_OTHER;
         }
-    } else if (room.controller) {
+    } else {
         delete data.owner;
         delete data.roomLevel;
         data.roomStatus = RoomMemoryStatus.VACANT;
     }
 
-    if (data.roomStatus !== RoomMemoryStatus.OWNED_ME) {
-        if (room.find(FIND_HOSTILE_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_TOWER && s.isActive() }).length || data.roomLevel) {
-            data.hostile = true;
-        }
+    if (data.roomStatus !== RoomMemoryStatus.OWNED_ME && data.roomLevel) {
+        data.hostile = true;
     } else {
         delete data.hostile;
     }

--- a/src/modules/misc.ts
+++ b/src/modules/misc.ts
@@ -1,0 +1,7 @@
+export function unfollowStructures() {
+    Object.values(Game.structures)
+        .filter((struct) => struct.structureType !== STRUCTURE_SPAWN)
+        .forEach((struct) => {
+            struct.notifyWhenAttacked(false);
+        });
+}

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -135,6 +135,10 @@ export function driveRoom(room: Room) {
             scanArea(room);
         }
 
+        if (room.powerSpawn?.store.power >= 1 && room.powerSpawn?.store.energy >= 50) {
+            room.powerSpawn.processPower();
+        }
+
         runLabs(room);
 
         runSpawning(room);

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -131,6 +131,10 @@ export function driveRoom(room: Room) {
             runGates(room);
         }
 
+        if (room.observer) {
+            scanArea(room);
+        }
+
         runLabs(room);
 
         runSpawning(room);
@@ -578,4 +582,61 @@ function runRemoteRooms(room: Room) {
             console.log(`Error caught running remote room ${remoteRoomName}: \n${e}`);
         }
     });
+}
+
+function scanArea(room: Room) {
+    let xDiff: number, yDiff: number;
+
+    //increment progress counter
+    if (room.memory.scanProgress === undefined || room.memory.scanProgress === '10.10') {
+        xDiff = -10;
+        yDiff = -10;
+    } else {
+        let values = room.memory.scanProgress.split('.').map((s) => parseInt(s));
+
+        if (values[1] === 10) {
+            xDiff = values[0] + 1;
+            yDiff = -10;
+        } else {
+            xDiff = values[0];
+            yDiff = values[1] + 1;
+        }
+    }
+
+    let scanTargetName = computeRoomNameFromDiff(room.name, xDiff, yDiff);
+
+    //get visiblity
+    room.observer.observeRoom(scanTargetName);
+    room.memory.scanProgress = `${xDiff}.${yDiff}`;
+}
+
+function computeRoomNameFromDiff(startingRoomName: string, xDiff: number, yDiff: number) {
+    //lets say W0 = E(-1), S1 = N(-1)
+
+    let values = startingRoomName
+        .replace('N', '.N')
+        .replace('S', '.S')
+        .split('.')
+        .map((v) => {
+            if (v.startsWith('E') || v.startsWith('N')) {
+                return parseInt(v.slice(1));
+            } else {
+                return -1 * parseInt(v.slice(1)) - 1;
+            }
+        });
+
+    let startX = values[0];
+    let startY = values[1];
+
+    let targetValues = [startX + xDiff, startY + yDiff];
+
+    return targetValues
+        .map((v, index) => {
+            if (v >= 0) {
+                return index === 0 ? 'E' + v : 'N' + v;
+            } else {
+                return index === 0 ? 'W' + (-1 * v - 1) : 'S' + (-1 * v - 1);
+            }
+        })
+        .reduce((sum, next) => sum + next);
 }

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -125,6 +125,14 @@ Object.defineProperty(Room.prototype, 'observer', {
     configurable: true,
 });
 
+Object.defineProperty(Room.prototype, 'powerSpawn', {
+    get: function (this: Room) {
+        return this.find(FIND_MY_STRUCTURES).find((s) => s.structureType === STRUCTURE_POWER_SPAWN && s.isActive());
+    },
+    enumerable: false,
+    configurable: true,
+});
+
 Room.prototype.addLabTask = function (this: Room, opts: LabTaskOpts): ScreepsReturnCode {
     return addLabTask(this, opts);
 };

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -117,6 +117,14 @@ Object.defineProperty(Room.prototype, 'factory', {
     configurable: true,
 });
 
+Object.defineProperty(Room.prototype, 'observer', {
+    get: function (this: Room) {
+        return this.find(FIND_MY_STRUCTURES).find((s) => s.structureType === STRUCTURE_OBSERVER && s.isActive());
+    },
+    enumerable: false,
+    configurable: true,
+});
+
 Room.prototype.addLabTask = function (this: Room, opts: LabTaskOpts): ScreepsReturnCode {
     return addLabTask(this, opts);
 };

--- a/src/roles/manager.ts
+++ b/src/roles/manager.ts
@@ -124,6 +124,29 @@ export class Manager extends WaveCreep {
             this.memory.targetId = storage.id;
             return;
         }
+
+        if (storage.store.power && powerSpawn?.store.power < powerSpawn?.store.getCapacity(RESOURCE_POWER) / 10) {
+            this.withdraw(
+                storage,
+                RESOURCE_POWER,
+                Math.min(this.store.getCapacity(), storage.store.power, powerSpawn.store.getFreeCapacity(RESOURCE_POWER))
+            );
+            this.memory.targetId = powerSpawn.id;
+            return;
+        }
+
+        if (
+            this.room.energyStatus >= EnergyStatus.STABLE &&
+            powerSpawn?.store.energy <= powerSpawn?.store.getCapacity(RESOURCE_ENERGY) - this.store.getCapacity()
+        ) {
+            this.withdraw(
+                storage,
+                RESOURCE_ENERGY,
+                Math.min(this.store.getCapacity(), storage.store.energy, powerSpawn.store.getFreeCapacity(RESOURCE_ENERGY))
+            );
+            this.memory.targetId = powerSpawn.id;
+            return;
+        }
     }
 
     private getResourceToTransferToTerminal(): MineralCompoundConstant {

--- a/src/virtualCreeps/waveCreep.ts
+++ b/src/virtualCreeps/waveCreep.ts
@@ -3,6 +3,9 @@ import { posFromMem } from '../modules/data';
 export class WaveCreep extends Creep {
     private static priorityQueue: Map<string, (creep: Creep) => void> = new Map();
     public drive() {
+        //disable notifications for all creeps
+        this.notifyWhenAttacked(false);
+
         if (this.memory.needsBoosted) {
             this.getNextBoost();
         } else if (this.memory.portalLocations?.[0]) {


### PR DESCRIPTION
This PR adds:

- automatic scanning of all rooms in range of owned rooms using observers
- automatic processing of power by manager
- automatic disabling of "notify when attacked" for all creeps & a function to manually disable for non-spawn structures