### PR TITLE
Melvin sandbox

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -1,4 +1,7 @@
 interface CreepMemory {
+    stop?: boolean;
+    ready?: number;
+    targetId2?: Id<Creep>;
     shouldBuildRoad?: boolean;
     gatheringLabResources?: boolean;
     needsBoosted?: boolean;

--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -71,6 +71,10 @@ interface TravelToOpts extends PathFinderOpts {
      * Additional goals (see PathFinder.search)
      */
     goals?: { pos: RoomPosition; range: number }[];
+    /**
+     * Do no allow creep to push other creeps when stuck
+     */
+    noPush?: Priority;
 }
 
 interface CustomMatrixCost {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -1,4 +1,5 @@
 interface RoomMemory {
+    towerAttacked?: number;
     needsWallRepair?: boolean;
     upgraderLinkPos?: string;
     managerLink?: Id<Structure>;

--- a/src/interfaces/structureSpawn.ts
+++ b/src/interfaces/structureSpawn.ts
@@ -6,7 +6,7 @@ interface StructureSpawn {
     spawnGatherer(remoteRoomName: string): ScreepsReturnCode;
     spawnReserver(remoteRoomName: string): ScreepsReturnCode;
     spawnManager(): ScreepsReturnCode;
-    spawnWorker(): ScreepsReturnCode;
+    spawnWorker(roomContainsViolentHostiles?: boolean): ScreepsReturnCode;
     spawnKeeperExterminator(remoteRoomName: string): ScreepsReturnCode;
     spawnRemoteMineralMiner(remoteRoomName: string): ScreepsReturnCode;
     spawnAssignedCreep(assignment: SpawnAssignment): ScreepsReturnCode;

--- a/src/modules/labManagement.ts
+++ b/src/modules/labManagement.ts
@@ -68,14 +68,19 @@ export function runLabs(room: Room) {
                     break;
             }
         } else if (task?.status === TaskStatus.PREPARING) {
-            let canStartTask =
-                task?.type === LabTaskType.BOOST
-                    ? task.reagentsNeeded
-                          .map((need) => Game.getObjectById(need.lab).store[need.resource] === need.amount)
-                          .reduce((readyState, next) => readyState && next)
-                    : task.reagentsNeeded
-                          .map((need) => Game.getObjectById(need.lab).store[need.resource])
-                          .reduce((readyState, next) => readyState && next);
+            let canStartTask: boolean;
+            if (task?.type === LabTaskType.BOOST && !Game.creeps[task.targetCreepName]) {
+                task.status = TaskStatus.COMPLETE;
+            } else {
+                canStartTask =
+                    task?.type === LabTaskType.BOOST
+                        ? task.reagentsNeeded
+                              .map((need) => Game.getObjectById(need.lab).store[need.resource] === need.amount)
+                              .reduce((readyState, next) => readyState && next)
+                        : task.reagentsNeeded
+                              .map((need) => Game.getObjectById(need.lab).store[need.resource] > 0)
+                              .reduce((readyState, next) => readyState && next);
+            }
 
             if (canStartTask) {
                 task.status = TaskStatus.ACTIVE;

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -238,6 +238,9 @@ function getPriceMap(): { [resourceType: string]: number } {
 }
 
 export function addHostileRoom(roomName: string) {
+    if (!Memory.roomData[roomName]) {
+        Memory.roomData[roomName] = { hostile: true, asOf: Game.time };
+    }
     Memory.roomData[roomName].hostile = true;
     Memory.roomData[roomName].asOf = Game.time;
 }

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -58,9 +58,8 @@ export class PopulationManagement {
         };
 
         // Increase during siege for more repair creeps
-        let t = roomContainsViolentHostiles && spawn.room.workerCapacity < 3 ? 1 : 0;
-
-        let canSupportAnotherWorker = workerCount < spawn.room.workerCapacity + t;
+        let canSupportAnotherWorker =
+            workerCount < spawn.room.workerCapacity + (roomContainsViolentHostiles && spawn.room.workerCapacity < 3 ? 1 : 0);
 
         let spawnUpgrader =
             canSupportAnotherWorker &&

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -41,7 +41,7 @@ const ROLE_TAG_MAP: { [key in Role]: string } = {
 };
 
 export class PopulationManagement {
-    static spawnWorker(spawn: StructureSpawn): ScreepsReturnCode {
+    static spawnWorker(spawn: StructureSpawn, roomContainsViolentHostiles?: boolean): ScreepsReturnCode {
         let workers = spawn.room.creeps.filter((creep) => creep.memory.role === Role.WORKER);
         let hasUpgrader = spawn.room.creeps.some((c) => c.memory.role === Role.UPGRADER);
         let roomNeedsConstruction =
@@ -50,13 +50,17 @@ export class PopulationManagement {
         let workerCount = workers.length + (hasUpgrader ? 1 : 0);
 
         let options: SpawnOptions = {
+            boosts: roomContainsViolentHostiles ? [BoostType.BUILD] : [],
             memory: {
                 room: spawn.room.name,
                 role: Role.WORKER,
             },
         };
 
-        let canSupportAnotherWorker = workerCount < spawn.room.workerCapacity;
+        // Increase during siege for more repair creeps
+        let t = roomContainsViolentHostiles && spawn.room.workerCapacity < 3 ? 1 : 0;
+
+        let canSupportAnotherWorker = workerCount < spawn.room.workerCapacity + t;
 
         let spawnUpgrader =
             canSupportAnotherWorker &&
@@ -66,7 +70,7 @@ export class PopulationManagement {
             !roomNeedsCoreStructures(spawn.room);
 
         const WORKER_PART_BLOCK = [WORK, CARRY, MOVE];
-        let creepLevelCap = 15;
+        let creepLevelCap = 16;
         if (spawnUpgrader) {
             options.memory.role = Role.UPGRADER;
             options.boosts = [BoostType.UPGRADE];
@@ -459,7 +463,7 @@ export class PopulationManagement {
                             let boostsAvailableCount = boostMap[boostType]?.map((boost) => boost.amount).reduce((sum, next) => sum + next) ?? 0;
                             if (boostsAvailableCount) {
                                 const nextAvailableBoostResource = boostMap[boostType].filter((boost) => boost.amount > 0)[0].resource;
-                                boostMap[nextAvailableBoostResource] -= 1;
+                                boostMap[boostType].filter((boost) => boost.amount > 0)[0].amount -= 1;
                                 const tierBoost =
                                     nextAvailableBoostResource.length > 2 ? nextAvailableBoostResource.length - 1 : nextAvailableBoostResource.length;
                                 this.updateNeededValues(part, needed, tierBoost);
@@ -542,7 +546,7 @@ export class PopulationManagement {
                             const boostsAvailableCount = boostMap[boostType]?.map((boost) => boost.amount).reduce((sum, next) => sum + next) ?? 0;
                             if (boostsAvailableCount) {
                                 const nextAvailableBoostResource = boostMap[boostType].filter((boost) => boost.amount > 0)[0].resource;
-                                boostMap[nextAvailableBoostResource] -= 1;
+                                boostMap[boostType].filter((boost) => boost.amount > 0)[0].amount -= 1;
                                 const tierBoost =
                                     nextAvailableBoostResource.length > 2 ? nextAvailableBoostResource.length - 1 : nextAvailableBoostResource.length;
                                 move -= this.getMove(part, tierBoost) * Math.ceil((parts.length - partRatio[MOVE]) / partRatio[MOVE]);

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -84,6 +84,10 @@ export function manageRemoteRoom(controllingRoomName: string, remoteRoomName: st
             body.push(HEAL, MOVE);
         }
 
+        // Cant beat enemy
+        if (body.length === 50) {
+            return;
+        }
         Memory.spawnAssignments.push({
             designee: controllingRoomName,
             body: body,

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -25,7 +25,12 @@ export function manageEmpireResources() {
             }
         } else if (!factory.store.getUsedCapacity()) {
             let batteryAmount = getResourceAmount(room, RESOURCE_BATTERY);
-            if (batteryAmount >= 50 && room.energyStatus < EnergyStatus.OVERFLOW && room.storage?.store.getFreeCapacity() > 100000) {
+            if (
+                batteryAmount >= 50 &&
+                room.name === 'W23S54' &&
+                room.energyStatus < EnergyStatus.OVERFLOW &&
+                room.storage?.store.getFreeCapacity() > 100000
+            ) {
                 let result = room.addFactoryTask(RESOURCE_ENERGY, Math.min(50000, batteryAmount * 10));
                 if (result === OK) {
                     console.log(`${room.name} added battery decompression task`);
@@ -237,7 +242,7 @@ export function getExtraResources(room: Room): ResourceConstant[] {
 
     const ALL_MINERALS_AND_COMPOUNDS = [...Object.keys(MINERAL_MIN_AMOUNT), ...Object.keys(REACTION_TIME)] as ResourceConstant[];
     ALL_MINERALS_AND_COMPOUNDS.forEach((resource) => {
-        if (getResourceAmount(room, resource) > 10000 && room.terminal.store[resource] >= 5000) {
+        if (resource !== RESOURCE_CATALYZED_UTRIUM_ACID && getResourceAmount(room, resource) > 10000 && room.terminal.store[resource] >= 5000) {
             extraResources.push(resource);
         }
     });

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -25,12 +25,7 @@ export function manageEmpireResources() {
             }
         } else if (!factory.store.getUsedCapacity()) {
             let batteryAmount = getResourceAmount(room, RESOURCE_BATTERY);
-            if (
-                batteryAmount >= 50 &&
-                room.name === 'W23S54' &&
-                room.energyStatus < EnergyStatus.OVERFLOW &&
-                room.storage?.store.getFreeCapacity() > 100000
-            ) {
+            if (batteryAmount >= 50 && room.energyStatus < EnergyStatus.OVERFLOW && room.storage?.store.getFreeCapacity() > 100000) {
                 let result = room.addFactoryTask(RESOURCE_ENERGY, Math.min(50000, batteryAmount * 10));
                 if (result === OK) {
                     console.log(`${room.name} added battery decompression task`);

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -237,7 +237,16 @@ export function getExtraResources(room: Room): ResourceConstant[] {
 
     const ALL_MINERALS_AND_COMPOUNDS = [...Object.keys(MINERAL_MIN_AMOUNT), ...Object.keys(REACTION_TIME)] as ResourceConstant[];
     ALL_MINERALS_AND_COMPOUNDS.forEach((resource) => {
-        if (resource !== RESOURCE_CATALYZED_UTRIUM_ACID && getResourceAmount(room, resource) > 10000 && room.terminal.store[resource] >= 5000) {
+        let maxResourceAmount = 10000;
+        // Increase Defensive Resource Amount
+        if (resource === RESOURCE_CATALYZED_UTRIUM_ACID) {
+            maxResourceAmount = 20000;
+        }
+        if (
+            resource !== RESOURCE_CATALYZED_UTRIUM_ACID &&
+            getResourceAmount(room, resource) > maxResourceAmount &&
+            room.terminal.store[resource] >= 5000
+        ) {
             extraResources.push(resource);
         }
     });

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -143,7 +143,7 @@ export function driveRoom(room: Room) {
             console.log(`Error caught running room ${room.name} for Labs: \n${e}`);
         }
 
-        if (!isHomeUnderAttack && room.name !== 'W23S54' && room.name !== 'W23S55') {
+        if (!isHomeUnderAttack && room.name !== 'W23S54') {
             runRemoteRooms(room);
         }
 
@@ -443,8 +443,7 @@ function runSpawning(room: Room) {
             room.energyStatus >= EnergyStatus.RECOVERING &&
             room.memory.remoteMiningRooms?.length &&
             !roomContainsViolentHostiles &&
-            room.name !== 'W23S54' &&
-            room.name !== 'W23S55'
+            room.name !== 'W23S54'
         ) {
             let exterminatorNeed = PopulationManagement.findExterminatorNeed(room);
             if (exterminatorNeed) {

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -37,7 +37,7 @@ export function driveRoom(room: Room) {
         room.memory.reservedEnergy = 0;
 
         let nukes = room.find(FIND_NUKES);
-        if (room.controller.level >= 6 && nukes.length) {
+        if (room.controller.level >= 6 && nukes.length && getStructuresToProtect(nukes)?.length) {
             let structuresAtRisk = getStructuresToProtect(nukes);
             structuresAtRisk.forEach((structureId) => {
                 let structure = Game.getObjectById(structureId);
@@ -131,31 +131,72 @@ export function driveRoom(room: Room) {
             runGates(room);
         }
 
-        runSpawning(room);
+        try {
+            runSpawning(room);
+        } catch (e) {
+            console.log(`Error caught running room ${room.name} for Spawning: \n${e}`);
+        }
 
-        runLabs(room);
+        try {
+            runLabs(room);
+        } catch (e) {
+            console.log(`Error caught running room ${room.name} for Labs: \n${e}`);
+        }
 
-        runRemoteRooms(room);
+        if (!isHomeUnderAttack && room.name !== 'W23S54' && room.name !== 'W23S55') {
+            runRemoteRooms(room);
+        }
 
         delete room.memory.reservedEnergy;
     }
 }
 
 function runTowers(room: Room, isRoomUnderAttack: boolean) {
-    // @ts-ignore
-    let towers: StructureTower[] = room.find(FIND_STRUCTURES).filter((structure) => structure.structureType === STRUCTURE_TOWER);
+    const towers = room.find(FIND_STRUCTURES).filter((structure) => structure.structureType === STRUCTURE_TOWER) as StructureTower[];
 
-    let myHurtCreep = room
+    const myHurtCreeps = room
         .find(FIND_MY_CREEPS)
-        .find((creep) => creep.hits < creep.hitsMax && (!isRoomUnderAttack || creep.memory.role === Role.RAMPART_PROTECTOR));
-    if (myHurtCreep) {
-        towers.forEach((tower) => tower.heal(myHurtCreep));
+        .filter(
+            (creep) =>
+                creep.hits < creep.hitsMax &&
+                (!isRoomUnderAttack ||
+                    creep.memory.role === Role.RAMPART_PROTECTOR ||
+                    creep.memory.role === Role.DISTRIBUTOR ||
+                    creep.memory.role === Role.WORKER)
+        );
+    if (myHurtCreeps.length) {
+        var mostHurtCreep = myHurtCreeps.reduce((mostHurt, nextCreep) => (mostHurt.hits < nextCreep.hits ? mostHurt : nextCreep));
+    }
+    if (mostHurtCreep) {
+        towers.forEach((tower) => tower.heal(mostHurtCreep));
         return;
     }
 
     if (!room.controller.safeMode) {
-        let hostileCreeps = room.find(FIND_HOSTILE_CREEPS, { filter: (creep) => !Memory.playersToIgnore?.includes(creep.owner.username) });
-        towers.forEach((tower) => tower.attack(tower.pos.findClosestByRange(hostileCreeps)));
+        const focus = Object.values(Game.creeps).find((creep) => creep.room.name === room.name && creep.memory.targetId2 && creep.memory.ready >= 5);
+        if (focus) {
+            towers.forEach((tower) => tower.attack(Game.getObjectById(focus.memory.targetId2)));
+        } else {
+            // Towers do not attack creeps on the edge because this can cause them to simply waste energy if two attackers are in the room and the healers go in and out of the room
+            const hostileCreep = room
+                .find(FIND_HOSTILE_CREEPS)
+                .filter((creep) => creep.owner.username === 'Invader' || (creep.pos.x > 1 && creep.pos.y < 48 && creep.pos.y > 1 && creep.pos.x < 48))
+                .find((creep) => {
+                    const hostileCreepInfo = CombatIntel.getCreepCombatData(room, true, creep.pos);
+                    const myCreepInfo = CombatIntel.getCreepCombatData(room, false, creep.pos);
+                    const myTowerInfo = CombatIntel.getTowerCombatData(room, false, creep.pos);
+                    return (
+                        CombatIntel.getPredictedDamage(
+                            myTowerInfo.dmgAtPos + myCreepInfo.totalDmg,
+                            hostileCreepInfo.highestDmgMultiplier,
+                            hostileCreepInfo.highestToughHits
+                        ) > hostileCreepInfo.totalHeal && !Memory.playersToIgnore?.includes(creep.owner.username)
+                    );
+                });
+            if (hostileCreep) {
+                towers.forEach((tower) => tower.attack(hostileCreep));
+            }
+        }
     }
 }
 
@@ -164,14 +205,14 @@ function runHomeSecurity(homeRoom: Room): boolean {
     const hostileCreepData = CombatIntel.getCreepCombatData(homeRoom, true);
 
     if (hostileCreepData.totalHeal < towerData.minDmg * hostileCreepData.highestDmgMultiplier) {
-        return; // Towers can handle it for sure
+        return false; // Towers can handle it for sure
     }
 
     if (
         homeRoom.memory.layout === RoomLayout.BUNKER &&
         hostileCreepData.totalHeal < CombatIntel.towerDamageAtRange(towerData, 12) * hostileCreepData.highestDmgMultiplier
     ) {
-        return; // Closest Creeps in BunkerLayout have to be in a range of 12 if they want to hit the ramparts in any way
+        return false; // Closest Creeps in BunkerLayout have to be in a range of 12 if they want to hit the ramparts in any way
     }
 
     // No Towers yet so spawn a protector with heal which can then kite the invader around
@@ -191,7 +232,7 @@ function runHomeSecurity(homeRoom: Room): boolean {
                 },
             });
         }
-        return;
+        return false;
     }
 
     let minNumHostileCreeps = homeRoom.controller.level < 4 ? 1 : 2;
@@ -199,26 +240,14 @@ function runHomeSecurity(homeRoom: Room): boolean {
     if (hostileCreepData.creeps.length >= minNumHostileCreeps) {
         // Spawn multiple rampartProtectors based on the number of enemy hostiles
         const currentNumProtectors = PopulationManagement.currentNumRampartProtectors(homeRoom.name);
-        if (!currentNumProtectors) {
-            const body = PopulationManagement.createPartsArray([RANGED_ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
-            Memory.spawnAssignments.push({
-                designee: homeRoom.name,
-                body: body,
-                spawnOpts: {
-                    boosts: [BoostType.RANGED_ATTACK],
-                    memory: {
-                        role: Role.RAMPART_PROTECTOR,
-                        room: homeRoom.name,
-                        currentTaskPriority: Priority.MEDIUM,
-                        combat: { flee: false },
-                    },
-                },
-            });
-        }
-        if (hostileCreepData.creeps.length >= 4 && currentNumProtectors - Math.floor(hostileCreepData.creeps.length / 2) < 0) {
+        let t = hostileCreepData.creeps.length > 12 ? 1 : -1;
+        if (
+            !currentNumProtectors ||
+            (hostileCreepData.creeps.length >= 4 && currentNumProtectors + t - Math.floor(hostileCreepData.creeps.length / 4) < 0)
+        ) {
             console.log(`Enemy Squad in homeRoom ${homeRoom.name}`);
             // Against squads we need two units (ranged for spread out dmg and melee for single target damage)
-            const attackerBody = PopulationManagement.createPartsArray([ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
+            const attackerBody = PopulationManagement.createPartsArray([ATTACK, ATTACK, ATTACK, ATTACK, MOVE], homeRoom.energyCapacityAvailable, 10);
             Memory.spawnAssignments.push({
                 designee: homeRoom.name,
                 body: attackerBody,
@@ -229,20 +258,6 @@ function runHomeSecurity(homeRoom: Room): boolean {
                         room: homeRoom.name,
                         assignment: homeRoom.name,
                         currentTaskPriority: Priority.HIGH,
-                        combat: { flee: false },
-                    },
-                },
-            });
-            const rangedBody = PopulationManagement.createPartsArray([RANGED_ATTACK, MOVE], homeRoom.energyCapacityAvailable, 25);
-            Memory.spawnAssignments.push({
-                designee: homeRoom.name,
-                body: rangedBody,
-                spawnOpts: {
-                    boosts: [BoostType.RANGED_ATTACK],
-                    memory: {
-                        role: Role.RAMPART_PROTECTOR,
-                        room: homeRoom.name,
-                        currentTaskPriority: Priority.MEDIUM,
                         combat: { flee: false },
                     },
                 },
@@ -392,7 +407,7 @@ function runSpawning(room: Room) {
         spawn?.spawnMax([CARRY, CARRY, MOVE], PopulationManagement.generateName(options.memory.role, spawn.name), options, 10);
     }
 
-    if (PopulationManagement.needsMiner(room) && !roomContainsViolentHostiles) {
+    if (PopulationManagement.needsMiner(room) && (!roomContainsViolentHostiles || room.memory.layout === undefined)) {
         let spawn = availableSpawns.pop();
         spawn?.spawnMiner();
     }
@@ -424,7 +439,13 @@ function runSpawning(room: Room) {
             }
         });
 
-        if (room.energyStatus >= EnergyStatus.RECOVERING && room.memory.remoteMiningRooms?.length && !roomContainsViolentHostiles) {
+        if (
+            room.energyStatus >= EnergyStatus.RECOVERING &&
+            room.memory.remoteMiningRooms?.length &&
+            !roomContainsViolentHostiles &&
+            room.name !== 'W23S54' &&
+            room.name !== 'W23S55'
+        ) {
             let exterminatorNeed = PopulationManagement.findExterminatorNeed(room);
             if (exterminatorNeed) {
                 let spawn = availableSpawns.pop();
@@ -457,7 +478,7 @@ function runSpawning(room: Room) {
         }
     }
 
-    if (!roomContainsViolentHostiles) {
+    if (!roomContainsViolentHostiles || room.memory.layout === undefined) {
         availableSpawns.forEach((spawn) => spawn.spawnWorker());
     }
 }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -165,11 +165,13 @@ function runTowers(room: Room, isRoomUnderAttack: boolean) {
                     creep.memory.role === Role.WORKER)
         );
     if (myHurtCreeps.length) {
-        var mostHurtCreep = myHurtCreeps.reduce((mostHurt, nextCreep) => (mostHurt.hits < nextCreep.hits ? mostHurt : nextCreep));
-    }
-    if (mostHurtCreep) {
-        towers.forEach((tower) => tower.heal(mostHurtCreep));
-        return;
+        const mostHurtCreep = myHurtCreeps.reduce((mostHurt, nextCreep) => (mostHurt.hits < nextCreep.hits ? mostHurt : nextCreep));
+
+        // TODO: Optimize to only heal as much as needed
+        if (mostHurtCreep) {
+            towers.forEach((tower) => tower.heal(mostHurtCreep));
+            return;
+        }
     }
 
     if (!room.controller.safeMode) {
@@ -240,10 +242,10 @@ function runHomeSecurity(homeRoom: Room): boolean {
     if (hostileCreepData.creeps.length >= minNumHostileCreeps) {
         // Spawn multiple rampartProtectors based on the number of enemy hostiles
         const currentNumProtectors = PopulationManagement.currentNumRampartProtectors(homeRoom.name);
-        let t = hostileCreepData.creeps.length > 12 ? 1 : -1;
         if (
             !currentNumProtectors ||
-            (hostileCreepData.creeps.length >= 4 && currentNumProtectors + t - Math.floor(hostileCreepData.creeps.length / 4) < 0)
+            (hostileCreepData.creeps.length >= 4 &&
+                currentNumProtectors + (hostileCreepData.creeps.length > 12 ? 1 : -1) - Math.floor(hostileCreepData.creeps.length / 4) < 0)
         ) {
             console.log(`Enemy Squad in homeRoom ${homeRoom.name}`);
             // Against squads we need two units (ranged for spread out dmg and melee for single target damage)

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -143,7 +143,7 @@ export function driveRoom(room: Room) {
             console.log(`Error caught running room ${room.name} for Labs: \n${e}`);
         }
 
-        if (!isHomeUnderAttack && room.name !== 'W23S54') {
+        if (!isHomeUnderAttack) {
             runRemoteRooms(room);
         }
 
@@ -439,12 +439,7 @@ function runSpawning(room: Room) {
             }
         });
 
-        if (
-            room.energyStatus >= EnergyStatus.RECOVERING &&
-            room.memory.remoteMiningRooms?.length &&
-            !roomContainsViolentHostiles &&
-            room.name !== 'W23S54'
-        ) {
+        if (room.energyStatus >= EnergyStatus.RECOVERING && room.memory.remoteMiningRooms?.length && !roomContainsViolentHostiles) {
             let exterminatorNeed = PopulationManagement.findExterminatorNeed(room);
             if (exterminatorNeed) {
                 let spawn = availableSpawns.pop();

--- a/src/prototypes/structureSpawn.ts
+++ b/src/prototypes/structureSpawn.ts
@@ -20,8 +20,8 @@ StructureSpawn.prototype.spawnReserver = function (remoteRoomName: string) {
     return PopulationManagement.spawnReserver(this, remoteRoomName);
 };
 
-StructureSpawn.prototype.spawnWorker = function () {
-    return PopulationManagement.spawnWorker(this);
+StructureSpawn.prototype.spawnWorker = function (roomContainsViolentHostiles?: boolean) {
+    return PopulationManagement.spawnWorker(this, roomContainsViolentHostiles);
 };
 
 StructureSpawn.prototype.spawnAssignedCreep = function (assignment: SpawnAssignment) {

--- a/src/roles/keeperExterminator.ts
+++ b/src/roles/keeperExterminator.ts
@@ -3,8 +3,8 @@ import { CombatCreep } from '../virtualCreeps/combatCreep';
 export class KeeperExterminator extends CombatCreep {
     private attacked: boolean = false;
     protected run() {
-        if (this.room.name === this.memory.assignment || this.memory.targetId) {
-            let target = Game.getObjectById(this.memory.targetId);
+        let target = Game.getObjectById(this.memory.targetId);
+        if (this.room.name === this.memory.assignment || target) {
             if (!target) {
                 this.memory.targetId = this.findTarget();
                 target = Game.getObjectById(this.memory.targetId);

--- a/src/roles/protector.ts
+++ b/src/roles/protector.ts
@@ -11,13 +11,7 @@ export class Protector extends CombatCreep {
             return; // Wait while creep is healing
         }
         if (this.travelToRoom(this.memory.assignment) === IN_ROOM || this.memory.targetId) {
-            if (
-                !this.memory.targetId ||
-                !Game.getObjectById(this.memory.targetId) ||
-                Game.getObjectById(this.memory.targetId).pos.roomName !== this.memory.assignment
-            ) {
-                this.memory.targetId = this.findTarget();
-            }
+            this.memory.targetId = this.findTarget();
             if (!this.memory.targetId) {
                 this.healSelf(false);
                 return;
@@ -62,12 +56,6 @@ export class Protector extends CombatCreep {
                 if (closestDangerousHostile) {
                     return closestDangerousHostile.id;
                 }
-            }
-
-            const healers = hostileCreeps.filter((creep) => creep.getActiveBodyparts(HEAL) > 0);
-
-            if (healers.length) {
-                return this.pos.findClosestByRange(healers).id;
             }
 
             const closestDangerousHostile = this.pos.findClosestByRange(hostileCreeps, {

--- a/src/roles/rampartProtector.ts
+++ b/src/roles/rampartProtector.ts
@@ -1,3 +1,4 @@
+import { CombatIntel } from '../modules/combatIntel';
 import { Pathing } from '../modules/pathing';
 import { CombatCreep } from '../virtualCreeps/combatCreep';
 
@@ -7,13 +8,40 @@ export class RampartProtector extends CombatCreep {
             this.heal(this);
         }
 
-        // First find the targetedRampart. If none is present (for example gcl < 4), then find the hostileCreep
-        if (!this.memory.targetId) {
-            const hostileCreepId = this.findTarget();
-            this.memory.targetId = this.getTargetedRampart(hostileCreepId);
-            if (!this.memory.targetId) {
-                this.memory.targetId = hostileCreepId;
+        // TODO: change this to not stop if already attacked (doesnt matter now since no move boost)
+        if (this.memory.stop) {
+            delete this.memory.stop;
+            return;
+        }
+
+        // Assasination
+        if (this.memory.ready >= 5) {
+            const targetCreep = Game.getObjectById(this.memory.targetId2);
+            const secondProtector = Object.values(Game.creeps).find(
+                (creep) => creep.id !== this.id && creep.room.name === this.room.name && creep.pos.isNearTo(targetCreep)
+            ) as RampartProtector;
+            if (targetCreep && secondProtector) {
+                secondProtector.memory.ready = 0;
+                if (this.pos.isNearTo(targetCreep) && secondProtector.pos.isNearTo(targetCreep)) {
+                    secondProtector.memory.stop = true;
+                    this.attack(targetCreep);
+                    secondProtector.attack(targetCreep);
+                    this.pathingToRampart(this, Game.getObjectById(this.memory.targetId) as StructureRampart);
+                    this.pathingToRampart(secondProtector, Game.getObjectById(this.memory.targetId) as StructureRampart);
+                }
             }
+            this.memory.ready = 0;
+            return;
+        }
+
+        // First find the targetedRampart. If none is present (for example gcl < 4), then find the hostileCreep
+        const hostileCreepId = this.findTarget();
+        this.memory.targetId2 = hostileCreepId;
+
+        this.memory.targetId = this.getTargetedRampart(hostileCreepId);
+
+        if (!this.memory.targetId) {
+            this.memory.targetId = hostileCreepId;
         }
         if (!this.memory.targetId) {
             this.memory.currentTaskPriority = Priority.LOW;
@@ -21,11 +49,124 @@ export class RampartProtector extends CombatCreep {
         }
         this.memory.currentTaskPriority = Priority.HIGH;
         const target = Game.getObjectById(this.memory.targetId);
-
         let creepActionReturnCode: CreepActionReturnCode;
         if (target instanceof StructureRampart) {
-            const targetCreep = Game.getObjectById(this.findTarget());
-            this.pathingToRampart(target);
+            let targetCreep = Game.getObjectById(hostileCreepId);
+            if (!this.pos.isNearTo(targetCreep)) {
+                const nearCreep = this.room
+                    .lookForAtArea(LOOK_CREEPS, this.pos.y - 1, this.pos.x - 1, this.pos.y + 1, this.pos.x + 1, true)
+                    .filter((lookObject) => !lookObject.creep.my);
+                if (nearCreep.length) {
+                    targetCreep = nearCreep[0].creep;
+                }
+            }
+            // Check for close Creeps to move toward and assasinate
+            if (
+                targetCreep &&
+                this.hits === this.hitsMax &&
+                this.ticksToLive > 7 &&
+                Pathing.sameCoord(this.pos, target.pos) &&
+                !Object.values(Game.creeps).some(
+                    (creep) => creep.id !== this.id && creep.memory.targetId2 === this.memory.targetId2 && creep.memory.ready > 0
+                ) &&
+                !targetCreep.getActiveBodyparts(ATTACK) &&
+                !this.fatigue &&
+                this.pos.getRangeTo(targetCreep) === 2
+            ) {
+                if (this.memory.ready === undefined) {
+                    this.memory.ready = 0;
+                }
+                this.memory.ready++;
+
+                if (this.memory.ready >= 3) {
+                    const secondProtector = Object.values(Game.creeps).find(
+                        (creep) =>
+                            creep.id !== this.id &&
+                            creep.room.name === this.room.name &&
+                            creep.ticksToLive > 5 &&
+                            creep.pos.getRangeTo(targetCreep) === 2 &&
+                            !creep.fatigue &&
+                            creep.hits === creep.hitsMax
+                    ) as RampartProtector;
+                    if (secondProtector && !this.canKill(targetCreep.pos, this, secondProtector)) {
+                        this.memory.ready = 0;
+                    }
+                    if (secondProtector) {
+                        secondProtector.memory.stop = true;
+                    }
+                    if (secondProtector && this.memory.ready >= 4) {
+                        const directionToEnemy = this.pos.getDirectionTo(targetCreep);
+                        const direction = secondProtector.pos.getDirectionTo(targetCreep);
+                        if (
+                            !Pathing.sameCoord(
+                                Pathing.positionAtDirection(this.pos, directionToEnemy),
+                                Pathing.positionAtDirection(secondProtector.pos, secondProtector.pos.getDirectionTo(targetCreep))
+                            )
+                        ) {
+                            let survive = true;
+                            survive = this.canSurvive(Pathing.positionAtDirection(this.pos, directionToEnemy));
+                            survive = this.canSurvive(
+                                Pathing.positionAtDirection(secondProtector.pos, secondProtector.pos.getDirectionTo(targetCreep))
+                            );
+                            if (!survive || Object.values(Game.creeps).some((creep) => creep.id !== this.id && creep.memory.ready >= 4)) {
+                                this.memory.ready = 0;
+                                return;
+                            }
+                            this.memory.ready++;
+                            this.move(directionToEnemy);
+                            secondProtector.move(direction);
+                            secondProtector.memory.targetId2 = this.memory.targetId2;
+                            return;
+                        } else if (
+                            Pathing.positionAtDirection(
+                                this.pos,
+                                (directionToEnemy + 1 === 9 ? 1 : directionToEnemy + 1) as DirectionConstant
+                            ).getRangeTo(targetCreep) === 1
+                        ) {
+                            let survive = true;
+                            survive = this.canSurvive(Pathing.positionAtDirection(this.pos, directionToEnemy));
+                            survive = this.canSurvive(
+                                Pathing.positionAtDirection(this.pos, (directionToEnemy + 1 === 9 ? 1 : directionToEnemy + 1) as DirectionConstant)
+                            );
+                            if (!survive || Object.values(Game.creeps).some((creep) => creep.id !== this.id && creep.memory.ready >= 4)) {
+                                this.memory.ready = 0;
+                                return;
+                            }
+                            this.memory.ready++;
+                            this.move(directionToEnemy + 1 === 9 ? 1 : ((directionToEnemy + 1) as DirectionConstant));
+                            secondProtector.move(direction);
+                            secondProtector.memory.targetId2 = this.memory.targetId2;
+                            return;
+                        } else if (
+                            Pathing.positionAtDirection(
+                                this.pos,
+                                (directionToEnemy - 1 === 0 ? 8 : directionToEnemy - 1) as DirectionConstant
+                            ).getRangeTo(targetCreep) === 1
+                        ) {
+                            let survive = true;
+                            survive = this.canSurvive(Pathing.positionAtDirection(this.pos, directionToEnemy));
+                            survive = this.canSurvive(
+                                Pathing.positionAtDirection(this.pos, (directionToEnemy - 1 === 0 ? 8 : directionToEnemy - 1) as DirectionConstant)
+                            );
+                            if (!survive || Object.values(Game.creeps).some((creep) => creep.id !== this.id && creep.memory.ready >= 4)) {
+                                this.memory.ready = 0;
+                                return;
+                            }
+                            this.memory.ready++;
+                            this.move(directionToEnemy - 1 === 0 ? 8 : ((directionToEnemy - 1) as DirectionConstant));
+                            secondProtector.move(direction);
+                            secondProtector.memory.targetId2 = this.memory.targetId2;
+                            return;
+                        }
+                    } else if (!secondProtector) {
+                        this.memory.ready = 0;
+                    }
+                }
+            } else {
+                this.memory.ready = 0;
+            }
+
+            this.pathingToRampart(this, target);
             creepActionReturnCode = this.attackCreep(targetCreep);
             if (this.pos.getRangeTo(targetCreep) > 1) {
                 creepActionReturnCode = ERR_NOT_IN_RANGE; // Creep should always reevaluate for closest rampart if there is no enemy creep in the vicinity (squads sometimes move to other parts that are only 2 blocks away so ranged will only attack one creep otherwise)
@@ -35,32 +176,130 @@ export class RampartProtector extends CombatCreep {
             creepActionReturnCode = this.attackCreep(target);
         }
 
-        if (creepActionReturnCode !== OK) {
-            delete this.memory.targetId;
+        if (Game.flags.dot) {
+            const creeps = this.room.lookForAt(LOOK_CREEPS, Game.flags.dot.pos.x, Game.flags.dot.pos.y);
+            if (creeps.length) {
+                this.attackCreep(creeps[0]);
+            }
         }
     }
 
-    private pathingToRampart(targetRampart: StructureRampart) {
+    /**
+     * Check if creep can survive for 2 ticks
+     * @param pos
+     */
+    private canSurvive(pos: RoomPosition) {
+        const hostileCreepInfo = CombatIntel.getCreepCombatData(this.room, true, pos);
+        const towerHeal = CombatIntel.getTowerCombatData(this.room, false, pos).healAtPos;
+
+        return 3 * (hostileCreepInfo.totalDmg - towerHeal) < 4000;
+    }
+
+    private canKill(pos: RoomPosition, creep1: Creep, creep2: Creep) {
+        const enemy = CombatIntel.getCreepCombatData(this.room, true, pos);
+        const towerDmg = CombatIntel.getTowerCombatData(this.room, false, pos).dmgAtPos;
+
+        // TODO: Technically only count self heal and subtract own creep damage by one tick of enemy damage since they first have to move into place
+        return (
+            enemy.highestHP + CombatIntel.getPredictedDamageNeeded(enemy.totalHeal / 1.5, enemy.highestDmgMultiplier, enemy.highestToughHits) <
+            towerDmg + CombatIntel.getTotalDamagePerCreepBody(creep1.body).attack + CombatIntel.getTotalDamagePerCreepBody(creep2.body).attack
+        );
+    }
+
+    private pathingToRampart(creep: Creep, targetRampart: StructureRampart) {
         // Already at target
-        if (!targetRampart || Pathing.sameCoord(this.pos, targetRampart.pos)) {
+        if (!targetRampart || Pathing.sameCoord(creep.pos, targetRampart.pos)) {
             return;
         }
 
-        this.travelTo(targetRampart, { preferRamparts: true });
+        creep.travelTo(targetRampart, { preferRamparts: true, efficiency: 0.2, maxRooms: 1, noPush: creep.memory.currentTaskPriority });
     }
 
     private findTarget(): Id<Creep> {
-        const hostileCreeps = this.room.find(FIND_HOSTILE_CREEPS);
-        if (hostileCreeps.length) {
-            const closestDangerousHostile = this.pos.findClosestByRange(hostileCreeps, {
-                filter: (creep: Creep) =>
-                    creep.body.some((bodyPart) => bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK || bodyPart.type === WORK),
-            });
+        let squads = this.identifySquads();
+        const alreadyTargeted = this.room.creeps
+            .filter((creep) => creep.id !== this.id && creep.memory.role === Role.RAMPART_PROTECTOR)
+            .map((creep) => creep.memory.targetId2);
+        alreadyTargeted.forEach((targetId) => {
+            squads = squads.filter((squad) => !squad.some((squadCreepId) => squadCreepId === targetId));
+        });
 
+        let hostileCreeps = this.room
+            .find(FIND_HOSTILE_CREEPS)
+            .filter(
+                (creep: Creep) =>
+                    creep.body.some(
+                        (bodyPart) => bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK || bodyPart.type === WORK || bodyPart.type === HEAL
+                    ) && squads.some((squad) => squad.some((squadCreepId) => squadCreepId === creep.id))
+            );
+
+        // If all squads are covered double team up
+        if (!hostileCreeps.length) {
+            const otherProtectors = Object.values(Game.creeps).filter(
+                (creep) =>
+                    this.id !== creep.id &&
+                    creep.memory.role === Role.RAMPART_PROTECTOR &&
+                    creep.memory.room === this.memory.room &&
+                    Game.getObjectById(creep.memory.targetId2)?.pos?.roomName === this.room.name
+            );
+
+            if (otherProtectors.length) {
+                // If in range to assasinate enemy creep
+                const closestCreeps = this.room
+                    .find(FIND_HOSTILE_CREEPS)
+                    .filter(
+                        (creep: Creep) =>
+                            creep.body.some(
+                                (bodyPart) =>
+                                    bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK || bodyPart.type === WORK || bodyPart.type === HEAL
+                            ) &&
+                            creep.pos.getRangeTo(this) <= 2 &&
+                            creep.ticksToLive > 30
+                    );
+                if (closestCreeps.length) {
+                    let closestProtector;
+                    const creepInRange = closestCreeps.find((hostileCreep) =>
+                        otherProtectors.find((protector) => {
+                            if (protector.pos.getRangeTo(hostileCreep) <= 2) {
+                                closestProtector = protector;
+                                return true;
+                            }
+                            return false;
+                        })
+                    );
+                    if (creepInRange && closestProtector) {
+                        if (closestProtector.memory) {
+                            closestProtector.memory.targetId2 = creepInRange.id;
+                        }
+                        return creepInRange.id;
+                    }
+                }
+
+                // Find an enemy that is only targeted by one protector
+                const enemyTargetIds = otherProtectors.map((protector) => protector.memory.targetId2);
+                const enemyWithOnlyOneProtector = enemyTargetIds.find(
+                    (targetId) => enemyTargetIds.indexOf(targetId) === enemyTargetIds.lastIndexOf(targetId)
+                );
+                if (enemyWithOnlyOneProtector) {
+                    return enemyWithOnlyOneProtector;
+                }
+            }
+        } else {
+            // TODO: closest to rampart instead?
+            const closestDangerousHostile = this.pos.findClosestByRange(hostileCreeps);
             if (closestDangerousHostile) {
                 return closestDangerousHostile.id;
             }
         }
+
+        // Shouldn't be needed but just in case nothing matched up
+        return this.room
+            .find(FIND_HOSTILE_CREEPS)
+            .find((creep: Creep) =>
+                creep.body.some(
+                    (bodyPart) => bodyPart.type === ATTACK || bodyPart.type === RANGED_ATTACK || bodyPart.type === WORK || bodyPart.type === HEAL
+                )
+            )?.id;
     }
 
     /**
@@ -77,32 +316,23 @@ export class RampartProtector extends CombatCreep {
                 ) as StructureRampart[];
 
             if (myRamparts.length) {
-                // Find all ramparts that are being attacked and not yet have a protector on them
-                const targetedRampart = myRamparts.find((rampart) =>
-                    this.room
-                        .lookAtArea(rampart.pos.y - 1, rampart.pos.x - 1, rampart.pos.y + 1, rampart.pos.x + 1, true)
-                        .find(
-                            (lookObject) =>
-                                lookObject.type === LOOK_CREEPS &&
-                                lookObject.creep?.owner?.username !== this.owner.username &&
-                                !rampart.pos.lookFor(LOOK_CREEPS).some((creep) => creep.memory.role === Role.RAMPART_PROTECTOR)
-                        )
-                );
-
-                if (targetedRampart) {
-                    return targetedRampart.id;
-                }
-
-                // If no rampart is getting attacked yet then get closest rampart to the enemy that isn't already taken
                 const closestHostile = Game.getObjectById(hostileCreepId);
                 let closestRampartToHostile = myRamparts.find((rampart) => Pathing.sameCoord(rampart.pos, this.pos));
 
                 myRamparts
-                    .filter((rampart) => !rampart.pos.lookFor(LOOK_CREEPS).some((creep) => creep.memory.role === Role.PROTECTOR))
+                    .filter(
+                        (rampart) =>
+                            !rampart.pos.lookFor(LOOK_CREEPS).some((creep) => creep.memory.role === Role.RAMPART_PROTECTOR) &&
+                            !Object.values(Game.creeps).some((creep) => creep.id !== this.id && creep.memory.targetId === rampart.id)
+                    )
                     .forEach((emptyRamparts) => {
+                        // Find closest rampart and prefer the ones that are in front of the enemy creep
                         if (
                             !closestRampartToHostile ||
-                            emptyRamparts.pos.getRangeTo(closestHostile.pos) < closestRampartToHostile.pos.getRangeTo(closestHostile.pos)
+                            emptyRamparts.pos.getRangeTo(closestHostile.pos) < closestRampartToHostile.pos.getRangeTo(closestHostile.pos) ||
+                            (this.pos.getDirectionTo(closestHostile.pos) % 2 === 0 &&
+                                emptyRamparts.pos.getRangeTo(closestHostile.pos) === closestRampartToHostile.pos.getRangeTo(closestHostile.pos) &&
+                                emptyRamparts.pos.getDirectionTo(closestHostile.pos) % 2 === 1)
                         ) {
                             closestRampartToHostile = emptyRamparts;
                         }

--- a/src/roles/remoteMineralMiner.ts
+++ b/src/roles/remoteMineralMiner.ts
@@ -12,7 +12,8 @@ export class RemoteMineralMiner extends WaveCreep {
         if (this.memory.destination && posFromMem(this.memory.destination).roomName === this.memory.room) {
             this.storeCargo();
             if (!this.store.getUsedCapacity()) {
-                if (this.ticksToLive < 200) {
+                const minTicks = isKeeperRoom(this.memory.assignment) ? 200 : 250;
+                if (this.ticksToLive < minTicks) {
                     this.suicide(); // Can be changed to recycle once implemented
                     return;
                 }

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -119,17 +119,15 @@ export class TransportCreep extends WaveCreep {
 
         let nonStorageSources: (Ruin | Resource | Structure)[];
 
-        if (this.room.name !== 'W23S55' && this.room.name !== 'W23S54') {
-            var ruins = this.room.find(FIND_RUINS, {
-                filter: (r) => {
-                    return r.store[RESOURCE_ENERGY];
-                },
-            });
+        var ruins = this.room.find(FIND_RUINS, {
+            filter: (r) => {
+                return r.store[RESOURCE_ENERGY];
+            },
+        });
 
-            var looseEnergyStacks = this.room
-                .find(FIND_DROPPED_RESOURCES)
-                .filter((res) => res.resourceType === RESOURCE_ENERGY && res.amount >= this.store.getCapacity());
-        }
+        var looseEnergyStacks = this.room
+            .find(FIND_DROPPED_RESOURCES)
+            .filter((res) => res.resourceType === RESOURCE_ENERGY && res.amount >= this.store.getCapacity());
         let containers = this.room
             .find(FIND_STRUCTURES)
             .filter((str) => str.structureType === STRUCTURE_CONTAINER && str.store.energy >= this.store.getCapacity());
@@ -231,18 +229,16 @@ export class TransportCreep extends WaveCreep {
             ).id;
         }
 
-        if (room.name !== 'W23S55' && room.name !== 'W23S54') {
-            var looseResources = room.find(FIND_DROPPED_RESOURCES);
-            if (looseResources.filter((r) => r.amount > 100).length) {
-                return looseResources.reduce((biggestResource, resourceToCompare) =>
-                    biggestResource.amount > resourceToCompare.amount ? biggestResource : resourceToCompare
-                ).id;
-            }
+        var looseResources = room.find(FIND_DROPPED_RESOURCES);
+        if (looseResources.filter((r) => r.amount > 100).length) {
+            return looseResources.reduce((biggestResource, resourceToCompare) =>
+                biggestResource.amount > resourceToCompare.amount ? biggestResource : resourceToCompare
+            ).id;
+        }
 
-            let tombstonesWithResources = room.find(FIND_TOMBSTONES).filter((t) => t.store.getUsedCapacity() > this.store.getCapacity() / 2);
-            if (tombstonesWithResources.length) {
-                return this.pos.findClosestByPath(tombstonesWithResources, { ignoreCreeps: true, range: 1 }).id;
-            }
+        let tombstonesWithResources = room.find(FIND_TOMBSTONES).filter((t) => t.store.getUsedCapacity() > this.store.getCapacity() / 2);
+        if (tombstonesWithResources.length) {
+            return this.pos.findClosestByPath(tombstonesWithResources, { ignoreCreeps: true, range: 1 }).id;
         }
 
         if (containers.length) {
@@ -250,10 +246,8 @@ export class TransportCreep extends WaveCreep {
                 fullestContainer.store.getUsedCapacity() > nextContainer.store.getUsedCapacity() ? fullestContainer : nextContainer
             ).id;
         }
-        if (room.name !== 'W23S55' && room.name !== 'W23S54') {
-            if (looseResources.length) {
-                return looseResources.reduce((most, next) => (most.amount > next.amount ? most : next)).id;
-            }
+        if (looseResources.length) {
+            return looseResources.reduce((most, next) => (most.amount > next.amount ? most : next)).id;
         }
     }
 

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -119,16 +119,16 @@ export class TransportCreep extends WaveCreep {
 
         let nonStorageSources: (Ruin | Resource | Structure)[];
 
-        var ruins = this.room.find(FIND_RUINS, {
+        const ruins = this.room.find(FIND_RUINS, {
             filter: (r) => {
                 return r.store[RESOURCE_ENERGY];
             },
         });
 
-        var looseEnergyStacks = this.room
+        const looseEnergyStacks = this.room
             .find(FIND_DROPPED_RESOURCES)
             .filter((res) => res.resourceType === RESOURCE_ENERGY && res.amount >= this.store.getCapacity());
-        let containers = this.room
+        const containers = this.room
             .find(FIND_STRUCTURES)
             .filter((str) => str.structureType === STRUCTURE_CONTAINER && str.store.energy >= this.store.getCapacity());
 
@@ -171,7 +171,7 @@ export class TransportCreep extends WaveCreep {
     }
 
     protected findRefillTarget(): Id<Structure> {
-        let towers = this.homeroom
+        const towers = this.homeroom
             .find(FIND_MY_STRUCTURES)
             .filter(
                 (structure) =>
@@ -180,18 +180,8 @@ export class TransportCreep extends WaveCreep {
         if (towers.length) {
             return this.pos.findClosestByPath(towers, { ignoreCreeps: true }).id;
         }
-        let labs = this.homeroom
-            .find(FIND_MY_STRUCTURES)
-            .filter(
-                (structure) =>
-                    structure.structureType === STRUCTURE_LAB &&
-                    this.previousTargetId !== structure.id &&
-                    structure.store.energy < structure.store.getCapacity(RESOURCE_ENERGY)
-            );
-        if (labs.length) {
-            return this.pos.findClosestByPath(labs, { ignoreCreeps: true }).id;
-        }
-        let spawnStructures = this.homeroom.find(FIND_MY_STRUCTURES).filter(
+
+        const spawnStructures = this.homeroom.find(FIND_MY_STRUCTURES).filter(
             (structure) =>
                 // @ts-ignore
                 [STRUCTURE_EXTENSION, STRUCTURE_SPAWN].includes(structure.structureType) &&
@@ -202,6 +192,18 @@ export class TransportCreep extends WaveCreep {
 
         if (spawnStructures.length) {
             return this.pos.findClosestByPath(spawnStructures, { ignoreCreeps: true }).id;
+        }
+
+        const labs = this.homeroom
+            .find(FIND_MY_STRUCTURES)
+            .filter(
+                (structure) =>
+                    structure.structureType === STRUCTURE_LAB &&
+                    this.previousTargetId !== structure.id &&
+                    structure.store.energy < structure.store.getCapacity(RESOURCE_ENERGY)
+            );
+        if (labs.length) {
+            return this.pos.findClosestByPath(labs, { ignoreCreeps: true }).id;
         }
     }
 
@@ -214,29 +216,29 @@ export class TransportCreep extends WaveCreep {
             return undefined;
         }
 
-        let labsNeedingEmptied = this.room.labs?.filter((lab) => lab.status === LabStatus.NEEDS_EMPTYING);
+        const labsNeedingEmptied = this.room.labs?.filter((lab) => lab.status === LabStatus.NEEDS_EMPTYING);
         if (labsNeedingEmptied.length) {
             return this.pos.findClosestByRange(labsNeedingEmptied).id;
         }
 
-        let containers: StructureContainer[] = room
+        const containers: StructureContainer[] = room
             .find(FIND_STRUCTURES)
             .filter((structure) => structure.structureType === STRUCTURE_CONTAINER && structure.store.getUsedCapacity()) as StructureContainer[];
-        let fillingContainers = containers.filter((container) => container.store.getUsedCapacity() >= container.store.getCapacity() / 2);
+        const fillingContainers = containers.filter((container) => container.store.getUsedCapacity() >= container.store.getCapacity() / 2);
         if (fillingContainers.length) {
             return fillingContainers.reduce((fullestContainer, nextContainer) =>
                 fullestContainer.store.getUsedCapacity() > nextContainer.store.getUsedCapacity() ? fullestContainer : nextContainer
             ).id;
         }
 
-        var looseResources = room.find(FIND_DROPPED_RESOURCES);
+        const looseResources = room.find(FIND_DROPPED_RESOURCES);
         if (looseResources.filter((r) => r.amount > 100).length) {
             return looseResources.reduce((biggestResource, resourceToCompare) =>
                 biggestResource.amount > resourceToCompare.amount ? biggestResource : resourceToCompare
             ).id;
         }
 
-        let tombstonesWithResources = room.find(FIND_TOMBSTONES).filter((t) => t.store.getUsedCapacity() > this.store.getCapacity() / 2);
+        const tombstonesWithResources = room.find(FIND_TOMBSTONES).filter((t) => t.store.getUsedCapacity() > this.store.getCapacity() / 2);
         if (tombstonesWithResources.length) {
             return this.pos.findClosestByPath(tombstonesWithResources, { ignoreCreeps: true, range: 1 }).id;
         }


### PR DESCRIPTION
Mainly defensive code:

- Towers only attack the enemy creep if they can kill it (they calculate all the possible heal they can get from themselves and surroundings and the additional TOUGH parts). The calculations always assume for the worst case (all enemy creeps in range heal the same creep).
- Doubled defensive resource limit
- Added defensive creep behavior. They can now leave the ramparts for a quick attack on the enemy if they are only one block away. They will retreat right after the attack. The towers should focus their attacks on the same creep to ensure a one-shot. 
- Creep memory could have been made a little nicer (targetId2, ready, stop). These names can still be improved
- Logic to check if the creep dmg + tower dmg is enough to one shot could also still be improved. The difficulty here is calculating the exact amount of damage they will take when moving out one space and then checking how much damage is left.
- Stop remoteMining while under attack
- Other minor changes