### PR TITLE
Fix obstacle creep pathing issue

### DIFF
--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -638,7 +638,7 @@ export class Pathing {
                     obstacleCreep.memory._m = { repath: 0 };
                 }
                 obstacleCreep.memory._m.repath++; // Since pushing a creep can mess with the path
-                return Pathing.moveObstacleCreep(obstacleCreep, nextDirection);
+                return Pathing.moveObstacleCreep(obstacleCreep, obstacleCreep.pos.getDirectionTo(creep));
             }
         }
         return false;


### PR DESCRIPTION
In a rare(ish) case, obstacle creeps were being pushed in the same direction as the pusher, even if the directions didn't work