### PR TITLE
Reduce CPU load from stamp distributors

### DIFF
--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -1,5 +1,4 @@
 interface CreepMemory {
-    stop?: boolean;
     ready?: number;
     targetId2?: Id<Creep>;
     gatheringLabResources?: boolean;
@@ -24,6 +23,9 @@ interface CreepMemory {
     combat?: CombatMemory;
     nextRole?: Role;
     storeRoadInMemory?: Id<StructureContainer>;
+    refillBelow: number;
+    sleepCollectTil: number;
+    stop?: boolean;
 }
 
 interface Creep {

--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -23,8 +23,8 @@ interface CreepMemory {
     combat?: CombatMemory;
     nextRole?: Role;
     storeRoadInMemory?: Id<StructureContainer>;
-    refillBelow: number;
-    sleepCollectTil: number;
+    refillBelow?: number;
+    sleepCollectTil?: number;
     stop?: boolean;
 }
 


### PR DESCRIPTION
- Prevent idle distributors from running all checks twice
- Add logic to prevent repetitive unnecessary extension/spawn checks
- Add cooldown period to collection check