### PR TITLE
Remote mining redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 dist
 .env
+.screeps-multimeter.history
+.screeps.yaml
+multimeter.log

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -16,6 +16,8 @@ declare global {
     var nextTickFunctions: (() => void)[];
 
     var visionRequestIncrement: number;
+
+    var remoteSourcesChecked: boolean;
 }
 
 export {};

--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -25,6 +25,7 @@ interface CreepMemory {
     storeRoadInMemory?: Id<StructureContainer>;
     sleepCollectTil?: number;
     stop?: boolean;
+    spawnReplacementAt?: number;
 }
 
 interface Creep {

--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -10,7 +10,7 @@ interface CreepMemory {
     link?: Id<StructureLink>;
     destination?: string;
     assignment?: string;
-    targetId?: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> | Id<Mineral>;
+    targetId?: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> | Id<Mineral> | Id<Source>;
     miningPos?: string;
     hasTTLReplacement?: boolean;
     gathering?: boolean;

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -11,7 +11,7 @@ interface Memory {
     blacklistedRooms?: string[]; //room names we don't sell to
     visionRequests?: { [id: string]: VisionRequest };
     remoteSourceClaims?: { [sourcePos: string]: { claimant: string; netIncome: number } }; //map of potential remote rooms to rooms intending to claim them and their anticipated net income - higher income gets priority
-    remoteSourceAssignments?: { [sourcePos: string]: string }; //maps sources in other rooms to owned rooms mining them
+    remoteSourceAssignments?: { [sourcePos: string]: RemoteAssignmentData }; //maps sources in other rooms to owned rooms mining them
     debug?: DebugSettings;
 }
 
@@ -161,4 +161,10 @@ interface DebugSettings {
     drawRoads?: boolean;
     drawRemoteConnections?: boolean;
     logRoomPlacementCpu?: boolean;
+}
+
+interface RemoteAssignmentData {
+    controllingRoom: string;
+    estimatedIncome: number;
+    roadLength: number;
 }

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -10,7 +10,7 @@ interface Memory {
     marketBlacklist?: string[]; //player names we don't want to sell to
     blacklistedRooms?: string[]; //room names we don't sell to
     visionRequests?: { [id: string]: VisionRequest };
-    remoteSourceClaims?: { [sourcePos: string]: { claimant: string; netIncome: number } }; //map of potential remote rooms to rooms intending to claim them and their anticipated net income - higher income gets priority
+    remoteSourceClaims?: { [sourcePos: string]: { claimant: string; estimatedIncome: number } }; //map of potential remote rooms to rooms intending to claim them and their anticipated net income - higher income gets priority
     remoteSourceAssignments?: { [sourcePos: string]: RemoteAssignmentData }; //maps sources in other rooms to owned rooms mining them
     debug?: DebugSettings;
 }

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -11,6 +11,7 @@ interface Memory {
     blacklistedRooms?: string[]; //room names we don't sell to
     visionRequests?: { [id: string]: VisionRequest };
     remoteRoomClaims?: { [targetRoom: string]: { claimant: string; depth: number } }; //map of potential remote rooms to rooms intending to claim them and their 'room distance' from - closer claimants get priority
+    remoteSourceAssignments?: { [sourcePos: string]: string }; //maps sources in other rooms to owned rooms mining them
 }
 
 interface EmpireIntershard {

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -12,6 +12,7 @@ interface Memory {
     visionRequests?: { [id: string]: VisionRequest };
     remoteSourceClaims?: { [sourcePos: string]: { claimant: string; netIncome: number } }; //map of potential remote rooms to rooms intending to claim them and their anticipated net income - higher income gets priority
     remoteSourceAssignments?: { [sourcePos: string]: string }; //maps sources in other rooms to owned rooms mining them
+    debug?: DebugSettings;
 }
 
 interface EmpireIntershard {
@@ -152,4 +153,11 @@ interface VisionRequest {
     assigned?: boolean;
     onTick?: number; //what tick is the vision required? undefined = immediately
     completed?: boolean; //once need is done, mark completed to remove
+}
+
+interface DebugSettings {
+    drawStamps?: boolean;
+    logCpu?: boolean;
+    drawRoads?: boolean;
+    drawRemoteConnections?: boolean;
 }

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -160,4 +160,5 @@ interface DebugSettings {
     logCpu?: boolean;
     drawRoads?: boolean;
     drawRemoteConnections?: boolean;
+    logRoomPlacementCpu?: boolean;
 }

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -10,7 +10,7 @@ interface Memory {
     marketBlacklist?: string[]; //player names we don't want to sell to
     blacklistedRooms?: string[]; //room names we don't sell to
     visionRequests?: { [id: string]: VisionRequest };
-    remoteRoomClaims?: { [targetRoom: string]: { claimant: string; depth: number } }; //map of potential remote rooms to rooms intending to claim them and their 'room distance' from - closer claimants get priority
+    remoteSourceClaims?: { [sourcePos: string]: { claimant: string; netIncome: number } }; //map of potential remote rooms to rooms intending to claim them and their anticipated net income - higher income gets priority
     remoteSourceAssignments?: { [sourcePos: string]: string }; //maps sources in other rooms to owned rooms mining them
 }
 

--- a/src/interfaces/pathingTypes.ts
+++ b/src/interfaces/pathingTypes.ts
@@ -91,6 +91,10 @@ interface TravelToOpts extends PathFinderOpts {
      * Avoid edges (first two tiles from exits). Useful for stamp layouts as these use ramparts at exits
      */
     avoidEdges?: boolean;
+    /**
+     * Use roads from roomdata.roads
+     */
+    useMemoryRoads?: boolean;
 }
 
 interface CustomMatrixCost {

--- a/src/interfaces/roads.ts
+++ b/src/interfaces/roads.ts
@@ -1,4 +1,5 @@
 interface RoadOpts {
     allowedStatuses?: RoomMemoryStatus[];
     ignoreOtherRoads?: boolean;
+    destRange?: number;
 }

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -14,7 +14,6 @@ interface RoomMemory {
     repairQueue: Id<Structure<StructureConstant>>[];
     miningAssignments: { [posString: string]: string };
     mineralMiningAssignments: { [posString: string]: string };
-    remoteMiningRooms?: string[];
     reservedEnergy?: number;
     layout?: RoomLayout;
     labTasks?: LabTask[];
@@ -25,15 +24,24 @@ interface RoomMemory {
     towerRepairMap?: { [towerId: string]: Id<StructureRoad> }; //maps towerId to roadId
     stampLayout?: Stamps;
     visionRequests?: string[]; //vision request Ids
-    outstandingClaim?: string; //roomName to be claimed
+    outstandingClaim?: string; //source to be claimed
+    remoteSources?: { [sourcePos: string]: RemoteSourceData };
+}
+
+interface RemoteSourceData {
+    miner: string;
+    gatherers: string[];
+    miningPos: string;
+    setupStatus?: RemoteSourceSetupStatus; //delete when done to save memory
+}
+
+const enum RemoteSourceSetupStatus {
+    BUILDING_CONTAINER = 1,
+    BUILDING_ROAD
 }
 
 interface RemoteData {
     reservationState?: RemoteRoomReservationStatus;
-    miningPositions: { [id: Id<Source>]: string }; // sourceId: miningPos
-    miner: string;
-    gatherer: string;
-    gathererSK?: string;
     reserver?: string;
     mineralMiner?: string;
     mineralAvailableAt?: number;
@@ -44,14 +52,13 @@ interface RemoteData {
 
 interface RoomData {
     asOf: number;
-    sourceCount?: number;
     sources?: string[];
     mineralType?: MineralConstant;
     roomStatus?: RoomMemoryStatus;
     owner?: string;
     hostile?: boolean;
     roomLevel?: number;
-    roads?: { [id: Id<Structure>]: string }; // RoomPosition: coordinates separated by delimiter
+    roads?: { [roadKey: string]: string }; // [startPos:endPos]: roadCode[]
 }
 
 const enum RoomMemoryStatus {
@@ -85,6 +92,8 @@ interface Room {
     observer: StructureObserver;
     powerSpawn: StructurePowerSpawn;
     stamps: Stamps;
+    remoteMiningRooms: string[];
+    remoteSources: string[];
 }
 
 interface RoomPosition {
@@ -177,6 +186,8 @@ const enum RoomLayout {
 
 interface RemoteStats {
     netIncome: number;
+    sourceSize: number
+    road: RoomPosition[];
     roadLength: number;
     roadMaintenance: number;
     containerMaintenance: number;
@@ -184,4 +195,5 @@ interface RemoteStats {
     gathererCount: number;
     gathererUpkeep: number;
     reserverUpkeep: number;
+    miningPos: RoomPosition
 }

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -26,6 +26,7 @@ interface RoomMemory {
     visionRequests?: string[]; //vision request Ids
     outstandingClaim?: string; //source to be claimed
     remoteSources?: { [sourcePos: string]: RemoteSourceData };
+    lastRemoteSourceCheck?: number;
 }
 
 interface RemoteSourceData {
@@ -37,7 +38,7 @@ interface RemoteSourceData {
 
 const enum RemoteSourceSetupStatus {
     BUILDING_CONTAINER = 1,
-    BUILDING_ROAD
+    BUILDING_ROAD,
 }
 
 interface RemoteData {
@@ -186,7 +187,7 @@ const enum RoomLayout {
 
 interface RemoteStats {
     netIncome: number;
-    sourceSize: number
+    sourceSize: number;
     road: RoomPosition[];
     roadLength: number;
     roadMaintenance: number;
@@ -195,5 +196,5 @@ interface RemoteStats {
     gathererCount: number;
     gathererUpkeep: number;
     reserverUpkeep: number;
-    miningPos: RoomPosition
+    miningPos: RoomPosition;
 }

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -186,7 +186,7 @@ const enum RoomLayout {
 }
 
 interface RemoteStats {
-    netIncome: number;
+    estimatedIncome: number;
     sourceSize: number;
     road: RoomPosition[];
     roadLength: number;
@@ -196,5 +196,6 @@ interface RemoteStats {
     gathererCount: number;
     gathererUpkeep: number;
     reserverUpkeep: number;
+    exterminatorUpkeep: number;
     miningPos: RoomPosition;
 }

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -45,6 +45,7 @@ interface RemoteData {
 interface RoomData {
     asOf: number;
     sourceCount?: number;
+    sources?: string[];
     mineralType?: MineralConstant;
     roomStatus?: RoomMemoryStatus;
     owner?: string;

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -174,3 +174,14 @@ const enum RoomLayout {
     BUNKER,
     STAMP,
 }
+
+interface RemoteStats {
+    netIncome: number;
+    roadLength: number;
+    roadMaintenance: number;
+    containerMaintenance: number;
+    minerUpkeep: number;
+    gathererCount: number;
+    gathererUpkeep: number;
+    reserverUpkeep: number;
+}

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -48,7 +48,7 @@ interface RemoteData {
     mineralAvailableAt?: number;
     threatLevel: RemoteRoomThreatLevel;
     keeperExterminator?: string;
-    sourceKeeperLairs?: { [id: Id<Source>]: Id<Structure<StructureConstant>> }; // keeperId: closestSourceId
+    sourceKeeperLairs?: { [sourcePos: string]: Id<Structure<StructureConstant>> }; // keeperId: closestSourceId
 }
 
 interface RoomData {

--- a/src/interfaces/structureSpawn.ts
+++ b/src/interfaces/structureSpawn.ts
@@ -2,8 +2,8 @@ interface StructureSpawn {
     spawnMineralMiner(): ScreepsReturnCode;
     spawnMiner(): ScreepsReturnCode;
     spawnDistributor(): ScreepsReturnCode;
-    spawnRemoteMiner: (remoteRoomName: string) => ScreepsReturnCode;
-    spawnGatherer(remoteRoomName: string): ScreepsReturnCode;
+    spawnRemoteMiner: (source: string) => ScreepsReturnCode;
+    spawnGatherer(source: string): ScreepsReturnCode;
     spawnReserver(remoteRoomName: string): ScreepsReturnCode;
     spawnManager(): ScreepsReturnCode;
     spawnWorker(roomContainsViolentHostiles?: boolean): ScreepsReturnCode;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import manageFlags from './modules/flagsManagement';
 import { manageMemory } from './modules/memoryManagement';
 import { manageEmpireResources } from './modules/resourceManagement';
 import { driveRoom } from './modules/roomManagement';
+import { runVisuals } from './modules/visuals';
 import { WaveCreep } from './virtualCreeps/waveCreep';
 require('./prototypes/requirePrototypes');
 
@@ -93,4 +94,13 @@ module.exports.loop = function () {
     if (Game.cpu.bucket === 10000) {
         Game.cpu.generatePixel();
     }
+
+    try {
+        runVisuals();
+    } catch (e) {
+        console.log(`Error caught running visuals: \n${e}`);
+    }
+
+    cpuUsageString += `visuals cpu: ${(Game.cpu.getUsed() - cpuUsed).toFixed(2)}     `;
+    cpuUsed = Game.cpu.getUsed();
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,14 +87,6 @@ module.exports.loop = function () {
         Game.creeps[creepName].runPriorityQueueTask();
     });
 
-    if (Memory.logCPU) {
-        console.log(cpuUsageString + `total: ${Game.cpu.getUsed().toFixed(2)}`);
-    }
-
-    if (Game.cpu.bucket === 10000) {
-        Game.cpu.generatePixel();
-    }
-
     try {
         runVisuals();
     } catch (e) {
@@ -103,4 +95,12 @@ module.exports.loop = function () {
 
     cpuUsageString += `visuals cpu: ${(Game.cpu.getUsed() - cpuUsed).toFixed(2)}     `;
     cpuUsed = Game.cpu.getUsed();
+
+    if (Memory.debug?.logCpu) {
+        console.log(cpuUsageString + `total: ${Game.cpu.getUsed().toFixed(2)}`);
+    }
+
+    if (Game.cpu.bucket === 10000) {
+        Game.cpu.generatePixel();
+    }
 };

--- a/src/modules/data.ts
+++ b/src/modules/data.ts
@@ -1,6 +1,6 @@
 export function addRoomData(room: Room) {
     let data: RoomData = {
-        sources: room.find(FIND_SOURCES).map(source => `${source.pos.x}.${source.pos.y}`),
+        sources: room.find(FIND_SOURCES).map((source) => `${source.pos.x}.${source.pos.y}`),
         mineralType: room.mineral?.mineralType,
         asOf: Game.time,
     };
@@ -178,4 +178,96 @@ export function addVisionRequest(request: VisionRequest): string | ScreepsReturn
 
 export function getExitDirections(roomName: string): DirectionConstant[] {
     return Object.keys(Game.map.describeExits(roomName)).map((key) => parseInt(key)) as DirectionConstant[];
+}
+
+export function getBunkerPositions(room: Room): RoomPosition[] {
+    if (room.memory.anchorPoint) {
+        let anchor = room.memory.anchorPoint.toRoomPos();
+        let posArr = [];
+        for (let i = -6; i < 7; i++) {
+            for (let j = -6; j < 7; j++) {
+                posArr.push(room.getPositionAt(anchor.x + i, anchor.y + j));
+            }
+        }
+        return posArr;
+    }
+}
+
+export function getStructureForPos(layout: RoomLayout, targetPos: RoomPosition, anchorPoint: RoomPosition): BuildableStructureConstant {
+    switch (layout) {
+        case RoomLayout.BUNKER:
+            let xdif = targetPos.x - anchorPoint.x;
+            let ydif = targetPos.y - anchorPoint.y;
+
+            if (targetPos === anchorPoint || Math.abs(xdif) >= 7 || Math.abs(ydif) >= 7) {
+                return undefined;
+            }
+
+            if (xdif === 0) {
+                switch (ydif) {
+                    case 1:
+                        return STRUCTURE_TERMINAL;
+                    case -1:
+                        return STRUCTURE_SPAWN;
+                    case -2:
+                    case 2:
+                    case -6:
+                    case 6:
+                        return STRUCTURE_EXTENSION;
+                    default:
+                        return STRUCTURE_ROAD;
+                }
+            }
+
+            if (ydif === 0) {
+                switch (xdif) {
+                    case -2:
+                        return STRUCTURE_OBSERVER;
+                    case -1:
+                        return STRUCTURE_LINK;
+                    case 1:
+                        return STRUCTURE_FACTORY;
+                    case 2:
+                        return STRUCTURE_SPAWN;
+                    default:
+                        return STRUCTURE_ROAD;
+                }
+            }
+
+            if (Math.abs(xdif) === 6 || Math.abs(ydif) === 6) {
+                return STRUCTURE_ROAD;
+            }
+
+            if (ydif === -1 && xdif === -1) {
+                return STRUCTURE_SPAWN;
+            }
+            if (ydif === -1 && xdif === 1) {
+                return STRUCTURE_STORAGE;
+            }
+            if (ydif === 1 && xdif === 1) {
+                return STRUCTURE_POWER_SPAWN;
+            }
+            if (ydif === 1 && xdif === -1) {
+                return STRUCTURE_NUKER;
+            }
+
+            if (Math.abs(ydif) === Math.abs(xdif) && Math.abs(ydif) <= 5) {
+                return STRUCTURE_ROAD;
+            }
+            if ((ydif === -3 && xdif >= -1 && xdif <= 2) || (xdif === 3 && ydif >= -2 && ydif <= 1)) {
+                return STRUCTURE_TOWER;
+            }
+            if (ydif <= -2 && ydif >= -5 && xdif <= -3 && xdif >= -4) {
+                return STRUCTURE_LAB;
+            }
+            if (ydif <= -3 && ydif >= -4 && (xdif === -2 || xdif === -5)) {
+                return STRUCTURE_LAB;
+            }
+
+            if ((Math.abs(ydif) === 2 && Math.abs(xdif) === 1) || (Math.abs(xdif) === 2 && Math.abs(ydif) === 1)) {
+                return STRUCTURE_ROAD;
+            }
+
+            return STRUCTURE_EXTENSION;
+    }
 }

--- a/src/modules/data.ts
+++ b/src/modules/data.ts
@@ -10,11 +10,6 @@ export function addRoomData(room: Room) {
     updateRoomData(room);
 }
 
-export function posFromMem(memPos: string): RoomPosition {
-    let split = memPos?.split('.');
-    return split ? new RoomPosition(Number(split[0]), Number(split[1]), split[2]) : null;
-}
-
 export function updateRoomData(room: Room) {
     let data = Memory.roomData[room.name];
 

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -41,12 +41,6 @@ export function manageMemory() {
         InterShardMemory.setLocal(JSON.stringify({ outboundCreeps: { shard0: {}, shard1: {}, shard2: {}, shard3: {} } }));
     }
 
-    Object.keys(Memory.roomData)
-        .filter((roomName) => Memory.roomData[roomName].hostile)
-        .forEach((roomName) => {
-            Game.map.visual.rect(new RoomPosition(0, 0, roomName), 50, 50, { fill: '#8b0000', stroke: '#8b0000', strokeWidth: 2 });
-        });
-
     if (!Memory.priceMap || Game.time % 20000 === 0) {
         Memory.priceMap = getPriceMap();
     }

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -254,6 +254,10 @@ function initMissingMemoryValues() {
     if (!Memory.remoteSourceAssignments) {
         Memory.remoteSourceAssignments = {};
     }
+
+    if (!Memory.debug){
+        Memory.debug = {};
+    }
 }
 
 function mangeVisionRequests() {

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -95,7 +95,7 @@ function handleDeadCreep(deadCreepName: string) {
         if (deadCreepMemory.role === Role.MINER && !deadCreepMemory.hasTTLReplacement) {
             Memory.rooms[deadCreepMemory.room].miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
-        if (deadCreepMemory.role === Role.REMOTE_MINER) {
+        if (deadCreepMemory.role === Role.REMOTE_MINER && Memory.rooms[deadCreepMemory.room].remoteSources[deadCreepMemory.assignment].miner === deadCreepName) {
             Memory.rooms[deadCreepMemory.room].remoteSources[deadCreepMemory.assignment].miner = AssignmentStatus.UNASSIGNED;
         }
         if (deadCreepMemory.role === Role.GATHERER) {
@@ -115,7 +115,7 @@ function handleDeadCreep(deadCreepName: string) {
         if (deadCreepMemory.role === Role.MINERAL_MINER) {
             Memory.rooms[deadCreepMemory.room].mineralMiningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
-        if (deadCreepMemory.role === Role.KEEPER_EXTERMINATOR && Memory.remoteData[deadCreepMemory.assignment]) {
+        if (deadCreepMemory.role === Role.KEEPER_EXTERMINATOR && Memory.remoteData[deadCreepMemory.assignment]?.keeperExterminator === deadCreepName) {
             Memory.remoteData[deadCreepMemory.assignment].keeperExterminator = AssignmentStatus.UNASSIGNED;
         }
         if (deadCreepMemory.role === Role.REMOTE_MINERAL_MINER && Memory.remoteData[deadCreepMemory.assignment]) {

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -255,6 +255,10 @@ function initMissingMemoryValues() {
     if (!Memory.remoteRoomClaims) {
         Memory.remoteRoomClaims = {};
     }
+
+    if (!Memory.remoteSourceAssignments) {
+        Memory.remoteSourceAssignments = {};
+    }
 }
 
 function mangeVisionRequests() {

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -96,12 +96,7 @@ function handleDeadCreep(deadCreepName: string) {
             Memory.rooms[deadCreepMemory.room].miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
         if (deadCreepMemory.role === Role.REMOTE_MINER) {
-            let source = Object.entries(Memory.rooms[deadCreepMemory.room].remoteSources).find(
-                ([key, value]) => value.miningPos === deadCreepMemory.assignment
-            )?.[0];
-            if (source) {
-                Memory.rooms[deadCreepMemory.room].remoteSources[source].miner = AssignmentStatus.UNASSIGNED;
-            }
+            Memory.rooms[deadCreepMemory.room].remoteSources[deadCreepMemory.assignment].miner = AssignmentStatus.UNASSIGNED;
         }
         if (deadCreepMemory.role === Role.GATHERER) {
             let source = Object.entries(Memory.rooms[deadCreepMemory.room].remoteSources).find(([source, data]) =>

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -31,6 +31,8 @@ export function manageMemory() {
 
     global.visionRequestIncrement = 1;
 
+    global.remoteSourcesChecked = false;
+
     deleteExpiredRoomData();
 
     let needToInitIntershard = !JSON.parse(InterShardMemory.getLocal())?.outboundCreeps;
@@ -64,16 +66,16 @@ export function validateAssignments() {
 
         Object.keys(Memory.rooms[roomName].remoteSources).forEach((source) => {
             let remoteRoomName = source.split('.')[2];
-            
+
             if (!Game.creeps[Memory.rooms[roomName].remoteSources[source].miner]) {
                 Memory.rooms[roomName].remoteSources[source].miner = AssignmentStatus.UNASSIGNED;
             }
 
             Memory.rooms[roomName].remoteSources[source].gatherers.forEach((gatherer, index) => {
-                if(!Game.creeps[gatherer]){
+                if (!Game.creeps[gatherer]) {
                     Memory.rooms[roomName].remoteSources[source].gatherers[index] = AssignmentStatus.UNASSIGNED;
                 }
-            })
+            });
 
             if (Memory.remoteData[remoteRoomName]?.reserver && !Game.creeps[Memory.remoteData[remoteRoomName].reserver]) {
                 Memory.remoteData[remoteRoomName].reserver = AssignmentStatus.UNASSIGNED;
@@ -93,20 +95,22 @@ function handleDeadCreep(deadCreepName: string) {
         if (deadCreepMemory.role === Role.MINER && !deadCreepMemory.hasTTLReplacement) {
             Memory.rooms[deadCreepMemory.room].miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
-        if (
-            deadCreepMemory.role === Role.REMOTE_MINER
-        ) {
-            let source = Object.entries(Memory.rooms[deadCreepMemory.room].remoteSources).find(([key, value]) => value.miningPos === deadCreepMemory.assignment)?.[0];
-            if(source){
+        if (deadCreepMemory.role === Role.REMOTE_MINER) {
+            let source = Object.entries(Memory.rooms[deadCreepMemory.room].remoteSources).find(
+                ([key, value]) => value.miningPos === deadCreepMemory.assignment
+            )?.[0];
+            if (source) {
                 Memory.rooms[deadCreepMemory.room].remoteSources[source].miner = AssignmentStatus.UNASSIGNED;
             }
         }
-        if (
-            deadCreepMemory.role === Role.GATHERER
-        ) {
-            let source = Object.entries(Memory.rooms[deadCreepMemory.room].remoteSources).find(([source, data]) => data.gatherers.includes(deadCreepName))?.[0];
-            let gathererIndex = Memory.rooms[deadCreepMemory.room].remoteSources[source]?.gatherers.findIndex(creepName => creepName === deadCreepName);
-            if(gathererIndex !== -1 && gathererIndex !== undefined){
+        if (deadCreepMemory.role === Role.GATHERER) {
+            let source = Object.entries(Memory.rooms[deadCreepMemory.room].remoteSources).find(([source, data]) =>
+                data.gatherers.includes(deadCreepName)
+            )?.[0];
+            let gathererIndex = Memory.rooms[deadCreepMemory.room].remoteSources[source]?.gatherers.findIndex(
+                (creepName) => creepName === deadCreepName
+            );
+            if (gathererIndex !== -1 && gathererIndex !== undefined) {
                 Memory.rooms[deadCreepMemory.room].remoteSources[source].gatherers[gathererIndex] = AssignmentStatus.UNASSIGNED;
             }
         }
@@ -255,7 +259,7 @@ function initMissingMemoryValues() {
         Memory.remoteSourceAssignments = {};
     }
 
-    if (!Memory.debug){
+    if (!Memory.debug) {
         Memory.debug = {};
     }
 }

--- a/src/modules/operationsManagement.ts
+++ b/src/modules/operationsManagement.ts
@@ -1,4 +1,4 @@
-import { addVisionRequest, posFromMem } from './data';
+import { addVisionRequest } from './data';
 import { Pathing } from './pathing';
 import { PopulationManagement } from './populationManagement';
 import { addRemoteRoom } from './remoteRoomManagement';
@@ -244,7 +244,7 @@ export function addOperation(operationType: OperationType, targetRoom: string, o
     delete opts?.originRoom;
 
     if (!originRoom) {
-        const originResult = findOperationOrigin(posFromMem(opts?.portalLocations?.[0])?.roomName ?? targetRoom, opts?.originOpts);
+        const originResult = findOperationOrigin(opts?.portalLocations?.[0]?.toRoomPos()?.roomName ?? targetRoom, opts?.originOpts);
         originRoom = originResult?.roomName;
         if (!opts?.pathCost) {
             if (!opts) {
@@ -596,7 +596,7 @@ function sortByBodyPart(prioritizedBodyPart: BodyPartConstant, bodyA: BodyPartCo
 }
 
 export function launchIntershardParty(portalLocations: string[], destinationRoom: string) {
-    let origin = findOperationOrigin(posFromMem(portalLocations[0]).roomName)?.roomName;
+    let origin = findOperationOrigin(portalLocations[0].toRoomPos().roomName)?.roomName;
 
     console.log(`launching intershard from ${origin}`);
 

--- a/src/modules/operationsManagement.ts
+++ b/src/modules/operationsManagement.ts
@@ -1,7 +1,6 @@
 import { addVisionRequest } from './data';
 import { Pathing } from './pathing';
 import { PopulationManagement } from './populationManagement';
-import { addRemoteRoom } from './remoteRoomManagement';
 import { getSpawnPos, placeBunkerConstructionSites, roomNeedsCoreStructures } from './roomDesign';
 
 const OPERATION_STARTING_STAGE_MAP: { [key in OperationType]?: OperationStage } = {
@@ -667,7 +666,7 @@ export function launchIntershardParty(portalLocations: string[], destinationRoom
 function manageAddRemoteMiningOperation(op: Operation) {
     //if target room has vision, perform functions
     if(Game.rooms[op.targetRoom]){
-        let result = addRemoteRoom(op.originRoom, op.targetRoom);
+        let result = undefined;//addRemoteRoom(op.originRoom, op.targetRoom);
         if(result != OK){
             console.log(`Problem assigning remote room ${op.targetRoom} to ${op.originRoom}: ${result}`);
         }

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -149,17 +149,17 @@ export class Pathing {
                     if (roadThruCurrentPos) {
                         pathFinder = { path: getRoadPathFromPos(roadThruCurrentPos[0], creep.pos, destination.toMemSafe()) };
                     } else {
-                        let roadPositions = _.flatten(roadsToDestination.map(([key, value]) => decodeRoad(value, creep.room.name)))
+                        let roadPositions = _.flatten(roadsToDestination.map(([key, value]) => decodeRoad(value, creep.room.name)));
                         //else find path to nearest pos on road
-                        pathFinder = PathFinder.search(
-                            creep.pos,
-                            roadPositions,
-                            {roomCallback: Pathing.getRoomCallback(creep.room.name, roadPositions.shift(), {}, creep.name) }
-                        );
+                        pathFinder = PathFinder.search(creep.pos, roadPositions, {
+                            roomCallback: Pathing.getRoomCallback(creep.room.name, roadPositions.shift(), {}, creep.name),
+                        });
                     }
                 }
             }
-            if (!pathFinder) {
+
+            //path could be empty if the creep is at the end of the road
+            if (!pathFinder?.path?.length) {
                 pathFinder = Pathing.findTravelPath(creep, creep.pos, destination, opts);
                 if (pathFinder.incomplete) {
                     // This can happen often ==> for example when "ignoreCreeps: false" was given and creeps are around the destination. Path close to target will still get serialized so not an issue.
@@ -289,7 +289,7 @@ export class Pathing {
     }
     //check two coordinates match
     static sameCoord(pos1: RoomPosition, pos2: RoomPosition): boolean {
-        return pos1.x === pos2.x && pos1.y === pos2.y;
+        return pos1.isEqualTo(pos2);
     }
 
     /**

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -1,4 +1,4 @@
-import { isKeeperRoom, posFromMem } from '../modules/data';
+import { isKeeperRoom } from '../modules/data';
 
 //@ts-ignore
 global.IN_ROOM = -20;
@@ -96,7 +96,7 @@ export class Pathing {
         }
 
         // Stuck Logic
-        if (!Pathing.isStuck(creep, posFromMem(creep.memory._m.lastCoord))) {
+        if (!Pathing.isStuck(creep, creep.memory._m.lastCoord.toRoomPos())) {
             creep.memory._m.stuckCount = 0;
             if (creep.memory._m.path) {
                 creep.memory._m.path = creep.memory._m.path.slice(1);
@@ -176,7 +176,7 @@ export class Pathing {
                 !creep.memory._m.keepPath &&
                 creep.memory._m.lastCoord &&
                 creep.memory._m.path?.length &&
-                Pathing.isExit(posFromMem(creep.memory._m.lastCoord)) &&
+                Pathing.isExit(creep.memory._m.lastCoord.toRoomPos()) &&
                 (!Pathing.positionAtDirection(creep.pos, parseInt(creep.memory._m.path[0], 10) as DirectionConstant) ||
                     Pathing.isExit(Pathing.positionAtDirection(creep.pos, parseInt(creep.memory._m.path[0], 10) as DirectionConstant)))
             ) {
@@ -200,18 +200,18 @@ export class Pathing {
             !creep.memory._m.keepPath &&
             opts.avoidSourceKeepers &&
             creep.memory._m.lastCoord &&
-            posFromMem(creep.memory._m.lastCoord).roomName !== creep.pos.roomName &&
+            creep.memory._m.lastCoord.toRoomPos().roomName !== creep.pos.roomName &&
             !creep.memory._m.visibleRooms.includes(creep.pos.roomName)
         ) {
             delete creep.memory._m.path; // Recalculate path in each new room as well if the creep should avoid hostiles in each room
-        } else if (creep.memory._m.lastCoord && posFromMem(creep.memory._m.lastCoord).roomName !== creep.pos.roomName && creep.memory._m.keepPath) {
+        } else if (creep.memory._m.lastCoord && creep.memory._m.lastCoord.toRoomPos().roomName !== creep.pos.roomName && creep.memory._m.keepPath) {
             creep.memory._m.keepPath = false;
         }
         return creep.move(nextDirection);
     }
 
     static isSameDest(creep: Creep, destination: RoomPosition) {
-        return JSON.stringify(posFromMem(creep.memory._m.destination)) === JSON.stringify(destination);
+        return JSON.stringify(creep.memory._m.destination.toRoomPos()) === JSON.stringify(destination);
     }
 
     /**
@@ -388,7 +388,7 @@ export class Pathing {
                 }
 
                 if (Memory.rooms[room.name]?.anchorPoint || Memory.rooms[room.name]?.managerPos) {
-                    let managerPos = posFromMem(room.memory.anchorPoint || room.memory.managerPos);
+                    let managerPos = room.memory.anchorPoint?.toRoomPos() || room.memory.managerPos?.toRoomPos();
                     if (!Pathing.sameCoord(managerPos, destination)) {
                         matrix.set(managerPos.x, managerPos.y, 50);
                     }
@@ -404,7 +404,7 @@ export class Pathing {
 
                 if (Memory.rooms[room.name]?.miningAssignments) {
                     Object.keys(room.memory.miningAssignments)
-                        .map((pos) => posFromMem(pos))
+                        .map((pos) => pos.toRoomPos())
                         .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
@@ -413,7 +413,7 @@ export class Pathing {
 
                 if (Memory.rooms[room.name]?.mineralMiningAssignments) {
                     Object.keys(room.memory.mineralMiningAssignments)
-                        .map((pos) => posFromMem(pos))
+                        .map((pos) => pos.toRoomPos())
                         .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
@@ -422,7 +422,7 @@ export class Pathing {
 
                 if (Memory.remoteData[room.name]?.miningPositions) {
                     Object.values(Memory.remoteData[room.name].miningPositions)
-                        .map((pos) => posFromMem(pos))
+                        .map((pos) => pos.toRoomPos())
                         .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
@@ -659,7 +659,7 @@ export class Pathing {
                     return true;
                 }
 
-                const obstacleCreepDestination = posFromMem(obstacleCreep.memory._m.destination);
+                const obstacleCreepDestination = obstacleCreep.memory._m.destination.toRoomPos();
                 // Swap places if creep is closer to the destination than the obstacleCreep
                 if (obstacleCreep.pos.getRangeTo(obstacleCreepDestination) >= creep.pos.getRangeTo(obstacleCreepDestination)) {
                     return Pathing.moveObstacleCreep(obstacleCreep, Pathing.inverseDirection(nextDirection));

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -141,7 +141,6 @@ export class Pathing {
                 const roadsToDestination = Object.entries(Memory.roomData[creep.room.name].roads).filter(([key, value]) =>
                     key.includes(destination.toMemSafe())
                 );
-                console.log(`${creep.name + ': ' + roadsToDestination.length}`);
                 if (roadsToDestination.length) {
                     let roadThruCurrentPos = roadsToDestination.find(([key, value]) =>
                         decodeRoad(value, creep.room.name).some((pos) => pos.isEqualTo(creep.pos))
@@ -150,10 +149,12 @@ export class Pathing {
                     if (roadThruCurrentPos) {
                         pathFinder = { path: getRoadPathFromPos(roadThruCurrentPos[0], creep.pos, destination.toMemSafe()) };
                     } else {
+                        let roadPositions = _.flatten(roadsToDestination.map(([key, value]) => decodeRoad(value, creep.room.name)))
                         //else find path to nearest pos on road
                         pathFinder = PathFinder.search(
                             creep.pos,
-                            _.flatten(roadsToDestination.map(([key, value]) => decodeRoad(value, creep.room.name)))
+                            roadPositions,
+                            {roomCallback: Pathing.getRoomCallback(creep.room.name, roadPositions.shift(), {}, creep.name) }
                         );
                     }
                 }
@@ -194,7 +195,6 @@ export class Pathing {
             creep.memory._m.path = Pathing.serializePath(creep.pos, pathFinder.path, { color: opts.pathColor, lineStyle: 'dashed' });
             // Get all roomPositions along the path
             if (opts.pathsRoomPositions?.length === 0 && creep.memory._m.path?.length && !opts.avoidedTemporaryHostileRooms) {
-                if (pathFinder.path[0] === undefined) console.log(`${creep.name}`);
                 Array.prototype.push.apply(opts.pathsRoomPositions, pathFinder.path);
             }
             creep.memory._m.stuckCount = 0;

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -137,7 +137,7 @@ export class Pathing {
 
             let pathFinder: any;
 
-            if (opts.useMemoryRoads && Memory.roomData[creep.room.name].roads) {
+            if (opts.useMemoryRoads && Memory.roomData[creep.room.name].roads && creep.memory._m.stuckCount < 3) {
                 const roadsToDestination = Object.entries(Memory.roomData[creep.room.name].roads).filter(([key, value]) =>
                     key.includes(destination.toMemSafe())
                 );
@@ -197,7 +197,7 @@ export class Pathing {
             if (opts.pathsRoomPositions?.length === 0 && creep.memory._m.path?.length && !opts.avoidedTemporaryHostileRooms) {
                 Array.prototype.push.apply(opts.pathsRoomPositions, pathFinder.path);
             }
-            creep.memory._m.stuckCount = 0;
+            //creep.memory._m.stuckCount = 0;
 
             // Do not remove next path if instantly going back to old room
             if (

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -96,7 +96,7 @@ export class Pathing {
         }
 
         // Stuck Logic
-        if (!Pathing.isStuck(creep, creep.memory._m.lastCoord.toRoomPos())) {
+        if (!Pathing.isStuck(creep, creep.memory._m.lastCoord?.toRoomPos())) {
             creep.memory._m.stuckCount = 0;
             if (creep.memory._m.path) {
                 creep.memory._m.path = creep.memory._m.path.slice(1);
@@ -176,7 +176,7 @@ export class Pathing {
                 !creep.memory._m.keepPath &&
                 creep.memory._m.lastCoord &&
                 creep.memory._m.path?.length &&
-                Pathing.isExit(creep.memory._m.lastCoord.toRoomPos()) &&
+                Pathing.isExit(creep.memory._m.lastCoord?.toRoomPos()) &&
                 (!Pathing.positionAtDirection(creep.pos, parseInt(creep.memory._m.path[0], 10) as DirectionConstant) ||
                     Pathing.isExit(Pathing.positionAtDirection(creep.pos, parseInt(creep.memory._m.path[0], 10) as DirectionConstant)))
             ) {
@@ -200,18 +200,18 @@ export class Pathing {
             !creep.memory._m.keepPath &&
             opts.avoidSourceKeepers &&
             creep.memory._m.lastCoord &&
-            creep.memory._m.lastCoord.toRoomPos().roomName !== creep.pos.roomName &&
+            creep.memory._m.lastCoord?.toRoomPos().roomName !== creep.pos.roomName &&
             !creep.memory._m.visibleRooms.includes(creep.pos.roomName)
         ) {
             delete creep.memory._m.path; // Recalculate path in each new room as well if the creep should avoid hostiles in each room
-        } else if (creep.memory._m.lastCoord && creep.memory._m.lastCoord.toRoomPos().roomName !== creep.pos.roomName && creep.memory._m.keepPath) {
+        } else if (creep.memory._m.lastCoord && creep.memory._m.lastCoord?.toRoomPos().roomName !== creep.pos.roomName && creep.memory._m.keepPath) {
             creep.memory._m.keepPath = false;
         }
         return creep.move(nextDirection);
     }
 
     static isSameDest(creep: Creep, destination: RoomPosition) {
-        return JSON.stringify(creep.memory._m.destination.toRoomPos()) === JSON.stringify(destination);
+        return JSON.stringify(creep.memory._m.destination?.toRoomPos()) === JSON.stringify(destination);
     }
 
     /**
@@ -404,7 +404,7 @@ export class Pathing {
 
                 if (Memory.rooms[room.name]?.miningAssignments) {
                     Object.keys(room.memory.miningAssignments)
-                        .map((pos) => pos.toRoomPos())
+                        .map((pos) => pos?.toRoomPos())
                         .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
@@ -413,16 +413,7 @@ export class Pathing {
 
                 if (Memory.rooms[room.name]?.mineralMiningAssignments) {
                     Object.keys(room.memory.mineralMiningAssignments)
-                        .map((pos) => pos.toRoomPos())
-                        .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
-                        .forEach((pos) => {
-                            matrix.set(pos.x, pos.y, 50);
-                        });
-                }
-
-                if (Memory.remoteData[room.name]?.miningPositions) {
-                    Object.values(Memory.remoteData[room.name].miningPositions)
-                        .map((pos) => pos.toRoomPos())
+                        .map((pos) => pos?.toRoomPos())
                         .filter((pos) => pos.x !== destination.x || pos.y !== destination.y)
                         .forEach((pos) => {
                             matrix.set(pos.x, pos.y, 50);
@@ -659,7 +650,7 @@ export class Pathing {
                     return true;
                 }
 
-                const obstacleCreepDestination = obstacleCreep.memory._m.destination.toRoomPos();
+                const obstacleCreepDestination = obstacleCreep.memory._m.destination?.toRoomPos();
                 // Swap places if creep is closer to the destination than the obstacleCreep
                 if (obstacleCreep.pos.getRangeTo(obstacleCreepDestination) >= creep.pos.getRangeTo(obstacleCreepDestination)) {
                     return Pathing.moveObstacleCreep(obstacleCreep, Pathing.inverseDirection(nextDirection));

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -364,7 +364,7 @@ export class PopulationManagement {
 
         let PARTS =
             spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD
-                ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyAvailable, 10)
+                ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyCapacityAvailable, 10)
                 : [
                       WORK,
                       WORK,

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -1,6 +1,5 @@
 import { isCenterRoom, isKeeperRoom as isKeeperRoom } from './data';
 import { getResourceBoostsAvailable } from './labManagement';
-import { posFromMem } from './data';
 import { roomNeedsCoreStructures } from './roomDesign';
 
 const BODY_TO_BOOST_MAP: Record<BoostType, BodyPartConstant> = {
@@ -186,7 +185,7 @@ export class PopulationManagement {
         //             creep.memory.room === room.name &&
         //             !creep.memory.hasTTLReplacement &&
         //             creep.ticksToLive <
-        //                 PopulationManagement.getMinerBody(posFromMem(creep.memory.assignment), room.energyCapacityAvailable).length * 3
+        //                 PopulationManagement.getMinerBody(creep.memory.assignment.toRoomPos(), room.energyCapacityAvailable).length * 3
         //     );
         // }
         return roomNeedsMiner;
@@ -237,7 +236,7 @@ export class PopulationManagement {
         //             creep.memory.role === Role.MINER &&
         //             creep.memory.room === spawn.room.name &&
         //             creep.ticksToLive <
-        //                 PopulationManagement.getMinerBody(posFromMem(creep.memory.assignment), spawn.room.energyCapacityAvailable).length * 3
+        //                 PopulationManagement.getMinerBody(creep.memory.assignment.toRoomPos(), spawn.room.energyCapacityAvailable).length * 3
         //     );
         //     assigment = currentMiner?.memory.assignment;
         // }
@@ -250,7 +249,7 @@ export class PopulationManagement {
             },
         };
 
-        let assigmentPos = posFromMem(assigment);
+        let assigmentPos = assigment.toRoomPos();
         let link = assigmentPos.findInRange(FIND_MY_STRUCTURES, 1).find((s) => s.structureType === STRUCTURE_LINK) as StructureLink;
         if (link) {
             options.memory.link = link.id;
@@ -769,7 +768,7 @@ export class PopulationManagement {
         // find safe spawn direction in predefined layouts
         if (spawn.room.memory?.layout === RoomLayout.BUNKER) {
             if (!opts.directions) {
-                let anchorPoint = posFromMem(spawn.room.memory.anchorPoint);
+                let anchorPoint = spawn.room.memory.anchorPoint.toRoomPos();
 
                 if (spawn.pos.x - anchorPoint.x === 0) {
                     opts.directions = [TOP_LEFT, TOP_RIGHT];
@@ -833,7 +832,7 @@ export class PopulationManagement {
 
         let levelCap = 8;
         if (spawn.room.memory?.layout === RoomLayout.BUNKER) {
-            let anchorPoint = posFromMem(spawn.room.memory.anchorPoint);
+            let anchorPoint = spawn.room.memory.anchorPoint.toRoomPos();
 
             if (spawn.pos.x - anchorPoint.x === 0) {
                 options.directions = [BOTTOM];
@@ -920,11 +919,11 @@ export class PopulationManagement {
         return Object.keys(mineralMiningAssignments).some(
             (k) =>
                 mineralMiningAssignments[k] === AssignmentStatus.UNASSIGNED &&
-                (Game.rooms[posFromMem(k)?.roomName]
-                    ? posFromMem(k)
+                (Game.rooms[k.toRoomPos()?.roomName]
+                    ? k.toRoomPos()
                           .findInRange(FIND_STRUCTURES, 1)
                           .filter((struct) => struct.structureType === STRUCTURE_EXTRACTOR && struct.isActive()).length &&
-                      Game.rooms[posFromMem(k)?.roomName].mineral.mineralAmount > 0
+                      Game.rooms[k.toRoomPos()?.roomName].mineral.mineralAmount > 0
                     : true)
         );
     }

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -980,6 +980,7 @@ export class PopulationManagement {
     }
 
     static findRemoteMineralMinerNeed(room: Room) {
+        return false;
         if (room.storage?.store.getFreeCapacity() < 100000 || room.storage?.store[room.mineral.mineralType] > 100000) {
             return false;
         }
@@ -1095,9 +1096,9 @@ export class PopulationManagement {
     }
 
     static calculateRemoteMinerWorkNeeded(miningPos: string) {
-        let energyPotential = isKeeperRoom(miningPos.toRoomPos().roomName) || isCenterRoom(miningPos.toRoomPos().roomName) ? 4000 * 3 : 3000;
+        let energyPotential = isKeeperRoom(miningPos.toRoomPos().roomName) || isCenterRoom(miningPos.toRoomPos().roomName) ? 4000 : 3000;
         let workNeeded = energyPotential / (HARVEST_POWER * 300);
 
-        return 1 + workNeeded > 5 ? 7 : 5;
+        return 1 + (workNeeded > 5 ? 7 : 5);
     }
 }

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -67,14 +67,14 @@ export class PopulationManagement {
             canSupportAnotherWorker &&
             !INCOMING_NUKE &&
             !hasUpgrader &&
-            (!roomNeedsConstruction || workers.length > 0) &&
+            !roomNeedsConstruction &&
             !roomNeedsCoreStructures(spawn.room);
 
         const WORKER_PART_BLOCK = [WORK, CARRY, MOVE];
         let creepLevelCap = 16;
         if (spawnUpgrader) {
             options.memory.role = Role.UPGRADER;
-            options.boosts = [BoostType.UPGRADE];
+            options.boosts = spawn.room.controller.level < 8 ? [BoostType.UPGRADE] : [];
             let result: ScreepsReturnCode;
 
             if (spawn.room.upgraderLink) {

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -286,11 +286,12 @@ export class PopulationManagement {
     }
 
     static findRemoteMinerNeed(room: Room): string {
-        return room.remoteSources.find(s => 
-            room.memory.remoteSources[s].miner === AssignmentStatus.UNASSIGNED &&
-            Memory.roomData[s.toRoomPos().roomName].roomStatus !== RoomMemoryStatus.OWNED_INVADER &&
-            Memory.remoteData[s.toRoomPos().roomName].threatLevel !== RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS &&
-            Memory.remoteData[s.toRoomPos().roomName].reservationState !== RemoteRoomReservationStatus.ENEMY
+        return room.remoteSources.find(
+            (s) =>
+                room.memory.remoteSources[s].miner === AssignmentStatus.UNASSIGNED &&
+                [RoomMemoryStatus.RESERVED_ME, RoomMemoryStatus.VACANT].includes(Memory.roomData[s.toRoomPos().roomName].roomStatus) &&
+                Memory.remoteData[s.toRoomPos().roomName].threatLevel !== RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS &&
+                Memory.remoteData[s.toRoomPos().roomName].reservationState !== RemoteRoomReservationStatus.ENEMY
         );
     }
 
@@ -339,7 +340,7 @@ export class PopulationManagement {
                 Memory.remoteData[s.toRoomPos().roomName].threatLevel !== RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS &&
                 Memory.remoteData[s.toRoomPos().roomName].reservationState !== RemoteRoomReservationStatus.ENEMY &&
                 room.memory.remoteSources[s].setupStatus !== RemoteSourceSetupStatus.BUILDING_CONTAINER &&
-                room.memory.remoteSources[s].gatherers.some(g => g === AssignmentStatus.UNASSIGNED)
+                room.memory.remoteSources[s].gatherers.some((g) => g === AssignmentStatus.UNASSIGNED)
         );
     }
 
@@ -367,14 +368,21 @@ export class PopulationManagement {
         //         ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyAvailable, 10)
         //         : [WORK, WORK, CARRY, CARRY, MOVE, ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9)];
 
-        let PARTS = [WORK, WORK, CARRY, CARRY, MOVE, ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9)];
+        let PARTS = [
+            WORK,
+            WORK,
+            CARRY,
+            CARRY,
+            MOVE,
+            ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9),
+        ];
         let result = spawn.smartSpawn(PARTS, name, options);
 
         if (result === OK) {
-            let unassignedIndex = spawn.room.memory.remoteSources[source].gatherers.findIndex(g => g === AssignmentStatus.UNASSIGNED);
+            let unassignedIndex = spawn.room.memory.remoteSources[source].gatherers.findIndex((g) => g === AssignmentStatus.UNASSIGNED);
             if (unassignedIndex !== -1) {
                 spawn.room.memory.remoteSources[source].gatherers[unassignedIndex] = name;
-            } 
+            }
         }
 
         return result;
@@ -934,7 +942,8 @@ export class PopulationManagement {
             (k) =>
                 mineralMiningAssignments[k] === AssignmentStatus.UNASSIGNED &&
                 (Game.rooms[k.toRoomPos()?.roomName]
-                    ? k.toRoomPos()
+                    ? k
+                          .toRoomPos()
                           .findInRange(FIND_STRUCTURES, 1)
                           .filter((struct) => struct.structureType === STRUCTURE_EXTRACTOR && struct.isActive()).length &&
                       Game.rooms[k.toRoomPos()?.roomName].mineral.mineralAmount > 0

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -296,17 +296,16 @@ export class PopulationManagement {
     }
 
     static spawnRemoteMiner(spawn: StructureSpawn, source: string): ScreepsReturnCode {
-        const miningPos = spawn.room.memory.remoteSources[source].miningPos;
         let options: SpawnOptions = {
             memory: {
-                assignment: miningPos,
+                assignment: source,
                 room: spawn.room.name,
                 role: Role.REMOTE_MINER,
                 currentTaskPriority: Priority.HIGH,
             },
         };
 
-        let workNeeded = this.calculateRemoteMinerWorkNeeded(miningPos);
+        let workNeeded = this.calculateRemoteMinerWorkNeeded(source);
         let work = [];
         let move = [];
         let energyLeft = spawn.room.energyCapacityAvailable - 100;
@@ -345,10 +344,9 @@ export class PopulationManagement {
     }
 
     static spawnGatherer(spawn: StructureSpawn, source: string): ScreepsReturnCode {
-        let miningPos = spawn.room.memory.remoteSources[source].miningPos;
         let options: SpawnOptions = {
             memory: {
-                assignment: miningPos,
+                assignment: source,
                 room: spawn.room.name,
                 role: Role.GATHERER,
             },

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -356,16 +356,18 @@ export class PopulationManagement {
         let name = this.generateName(options.memory.role, spawn.name);
 
         //if road is marked as in-progress, check to see if it is done
-        if(spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD){
-            let roadFinished = roadIsPaved(`${getStoragePos(spawn.room).toMemSafe()}:${source}`);
-            if(roadFinished === true){
-                delete spawn.room.memory.remoteSources[source].setupStatus;
-            }
-        }
+        // if(spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD){
+        //     let roadFinished = roadIsPaved(`${getStoragePos(spawn.room).toMemSafe()}:${source}`);
+        //     if(roadFinished === true){
+        //         delete spawn.room.memory.remoteSources[source].setupStatus;
+        //     }
+        // }
 
-        let PARTS = spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD
-                ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyAvailable, 10)
-                : [WORK, WORK, CARRY, CARRY, MOVE, ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9)];
+        // let PARTS = spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD
+        //         ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyAvailable, 10)
+        //         : [WORK, WORK, CARRY, CARRY, MOVE, ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9)];
+
+        let PARTS = [WORK, WORK, CARRY, CARRY, MOVE, ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9)];
         let result = spawn.smartSpawn(PARTS, name, options);
 
         if (result === OK) {

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -357,25 +357,33 @@ export class PopulationManagement {
         let name = this.generateName(options.memory.role, spawn.name);
 
         //if road is marked as in-progress, check to see if it is done
-        // if(spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD){
-        //     let roadFinished = roadIsPaved(`${getStoragePos(spawn.room).toMemSafe()}:${source}`);
-        //     if(roadFinished === true){
-        //         delete spawn.room.memory.remoteSources[source].setupStatus;
-        //     }
-        // }
+        if (spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD) {
+            let roadFinished = roadIsPaved(`${getStoragePos(spawn.room).toMemSafe()}:${spawn.room.memory.remoteSources[source].miningPos}`);
+            if (roadFinished === true) {
+                delete spawn.room.memory.remoteSources[source].setupStatus;
+            }
+        }
 
-        // let PARTS = spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD
-        //         ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyAvailable, 10)
-        //         : [WORK, WORK, CARRY, CARRY, MOVE, ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9)];
+        let PARTS =
+            spawn.room.memory.remoteSources[source].setupStatus === RemoteSourceSetupStatus.BUILDING_ROAD
+                ? PopulationManagement.createPartsArray([WORK, CARRY, MOVE], spawn.room.energyAvailable, 10)
+                : [
+                      WORK,
+                      WORK,
+                      CARRY,
+                      CARRY,
+                      MOVE,
+                      ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9),
+                  ];
 
-        let PARTS = [
-            WORK,
-            WORK,
-            CARRY,
-            CARRY,
-            MOVE,
-            ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9),
-        ];
+        // let PARTS = [
+        //     WORK,
+        //     WORK,
+        //     CARRY,
+        //     CARRY,
+        //     MOVE,
+        //     ...PopulationManagement.createPartsArray([CARRY, CARRY, CARRY, CARRY, MOVE], spawn.room.energyCapacityAvailable - 350, 9),
+        // ];
         let result = spawn.smartSpawn(PARTS, name, options);
 
         if (result === OK) {

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -10,7 +10,7 @@ function calculateSourceRoadStats(
 ): { road: RoomPosition[], roadLength: number; maintenanceCost: number; miningPos: RoomPosition } {
     let storagePos = getStoragePos(room);
 
-    const road = getRoad(storagePos, sourcePos, {allowedStatuses: [RoomMemoryStatus.OWNED_INVADER, RoomMemoryStatus.RESERVED_ME, RoomMemoryStatus.VACANT], ignoreOtherRoads: ignoreRoomDataRoads, destRange: 1});
+    const road = getRoad(storagePos, sourcePos, {allowedStatuses: [RoomMemoryStatus.RESERVED_INVADER, RoomMemoryStatus.RESERVED_ME, RoomMemoryStatus.VACANT], ignoreOtherRoads: ignoreRoomDataRoads, destRange: 1});
 
     if (road.incomplete) {
         return { roadLength: -1, maintenanceCost: -1, miningPos: undefined, road: undefined };
@@ -253,9 +253,11 @@ export function findSuitableRemoteSource(room: Room, noKeeperRooms: boolean = fa
 
     remoteRooms.forEach(remoteRoom => isKeeperRoom(remoteRoom) || isCenterRoom(remoteRoom) ? keeperRoomsMined++ : otherRoomsMined++);
 
+    options.forEach(option => console.log(`${option.source}: ${option.stats?.netIncome}`))
+
     if (noKeeperRooms || room.controller.level < 7 || keeperRoomsMined >= 2) {
         //pre-7 rooms can't handle central room upkeep
-        options = options.filter((option) => option.stats.sourceSize === 3000);
+        options = options.filter((option) => option.stats?.sourceSize === 3000);
     } 
 
     //prefer central rooms over other rooms and prefer closer to farther

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -1,0 +1,51 @@
+import { getStoragePos } from './roomDesign';
+
+export function calculateRemoteSourceCost(sourcePos: RoomPosition, room: Room) {
+    let storagePos = getStoragePos(room);
+    console.log(storagePos);
+
+    const path = PathFinder.search(
+        storagePos,
+        { pos: sourcePos, range: 1 },
+        {
+            plainCost: 2,
+            swampCost: 10,
+            roomCallback: (roomName: string) => {
+                if (
+                    roomName !== room.name &&
+                    ![RoomMemoryStatus.RESERVED_ME, RoomMemoryStatus.RESERVED_INVADER, RoomMemoryStatus.VACANT].includes(
+                        Memory.roomData[roomName]?.roomStatus
+                    )
+                ) {
+                    return false;
+                }
+
+                let matrix = new PathFinder.CostMatrix();
+                let roads = Memory.roomData[roomName]?.roads ? Object.values(Memory.roomData[roomName].roads) : [];
+                if (roads?.length) {
+                    roads.forEach((road) =>
+                        road.split(',').forEach((posString) => {
+                            let split = posString.split(':').map((v) => parseInt(v));
+                            matrix.set(split[0], split[1], 1);
+                        })
+                    );
+                }
+
+                if (roomName === room.name) {
+                    room.stamps?.road.forEach((r) => {
+                        if (r.rcl <= room.controller.level) matrix.set(r.pos.x, r.pos.y, 1);
+                    });
+                }
+
+                return matrix;
+            },
+            maxOps: 10000,
+        }
+    );
+
+    if (path.incomplete) {
+        return ERR_NOT_IN_RANGE;
+    }
+
+    return path.cost;
+}

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -235,7 +235,7 @@ export function findRemoteMiningOptions(roomName: string, noKeeperRooms?: boolea
     }
 
     let safeRoomsDepthTwo: string[] = [];
-    for (let depthOneRoomName of safeRoomsDepthOne) {
+    for (let depthOneRoomName of safeRoomsDepthOne.filter((room) => !isKeeperRoom(room) || Memory.remoteData[room])) {
         let depthOneExits = getExitDirections(depthOneRoomName);
         for (let exit of depthOneExits) {
             let nextRoomName =
@@ -255,7 +255,7 @@ export function findRemoteMiningOptions(roomName: string, noKeeperRooms?: boolea
     }
 
     let safeRoomsDepthThree: string[] = [];
-    for (let depthTwoRoomName of safeRoomsDepthTwo) {
+    for (let depthTwoRoomName of safeRoomsDepthTwo.filter((room) => !isKeeperRoom(room) || Memory.remoteData[room])) {
         let depthTwoExits = getExitDirections(depthTwoRoomName);
         for (let exit of depthTwoExits) {
             let nextRoomName =
@@ -268,9 +268,8 @@ export function findRemoteMiningOptions(roomName: string, noKeeperRooms?: boolea
                 ) &&
                 !safeRoomsDepthOne.includes(nextRoomName) &&
                 !safeRoomsDepthTwo.includes(nextRoomName) &&
-                noKeeperRooms
-                    ? !isKeeperRoom(nextRoomName) && !isCenterRoom(nextRoomName)
-                    : true
+                !isKeeperRoom(nextRoomName) &&
+                !isCenterRoom(nextRoomName)
             ) {
                 safeRoomsDepthThree.push(nextRoomName);
             }

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -306,10 +306,10 @@ export function findSuitableRemoteSource(roomName: string, noKeeperRooms: boolea
         options = options.filter((option) => option.stats?.sourceSize === 3000);
     }
 
-    options = options.filter((option) => option.stats.estimatedIncome >= 750);
+    options = options.filter((option) => option.stats.estimatedIncome / option.stats.gathererCount >= 750);
 
     //prefer central rooms over other rooms and prefer closer to farther
-    options.sort((a, b) => b.stats.estimatedIncome - a.stats.estimatedIncome);
+    options.reduce((highest, next) => next.stats.estimatedIncome > highest.stats.estimatedIncome ? next : highest);
 
     return options.shift();
 }

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -53,6 +53,8 @@ export function calculateRoadStats(
 
     if (path.incomplete) {
         return { roadLength: -1, maintenanceCost: -1 };
+    } else {
+        path.path.pop();
     }
 
     let visualRooms = Array.from(new Set(path.path.map((pos) => pos.roomName)));
@@ -66,12 +68,15 @@ export function calculateRoadStats(
     return { roadLength: path.path.length, maintenanceCost: MAINTENANCE_COST_PER_CYCLE };
 }
 
-export function calculateRemoteSourceStats(sourcePos: RoomPosition, room: Room, ignoreRoomDataRoads = false) {
+export function calculateRemoteSourceStats(sourcePos: RoomPosition, room: Room, ignoreRoomDataRoads = false): RemoteStats {
     //Energy output of source per regen cycle
     const SOURCE_OUTPUT_PER_CYCLE =
         isKeeperRoom(sourcePos.roomName) || isCenterRoom(sourcePos.roomName) ? SOURCE_ENERGY_KEEPER_CAPACITY : SOURCE_ENERGY_CAPACITY;
 
     const roadStats = calculateRoadStats(sourcePos, room, ignoreRoomDataRoads);
+    if (roadStats.maintenanceCost === -1) {
+        return undefined;
+    }
 
     //Cost of road maintenance per source regen cycle
     const ROAD_MAINTENANCE_PER_CYCLE = roadStats.maintenanceCost;

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -151,7 +151,11 @@ export function assignRemoteSource(source: string, roomName: string) {
             gatherers.push(AssignmentStatus.UNASSIGNED);
         }
 
-        Memory.remoteSourceAssignments[source] = roomName;
+        Memory.remoteSourceAssignments[source] = {
+            controllingRoom: roomName,
+            estimatedIncome: stats.netIncome,
+            roadLength: stats.roadLength,
+        };
 
         Memory.rooms[roomName].remoteSources[source] = {
             gatherers: gatherers,
@@ -188,9 +192,9 @@ export function assignRemoteSource(source: string, roomName: string) {
 
 export function removeSourceAssignment(source: string) {
     let current = Memory.remoteSourceAssignments[source];
-    Game.creeps[Memory.rooms[current].remoteSources[source]?.miner]?.suicide();
-    Memory.rooms[current].remoteSources[source]?.gatherers.forEach((g) => Game.creeps[g].suicide());
-    delete Memory.rooms[current].remoteSources[source];
+    Game.creeps[Memory.rooms[current.controllingRoom].remoteSources[source]?.miner]?.suicide();
+    Memory.rooms[current.controllingRoom].remoteSources[source]?.gatherers.forEach((g) => Game.creeps[g].suicide());
+    delete Memory.rooms[current.controllingRoom].remoteSources[source];
     delete Memory.remoteSourceAssignments[source];
     let roomName = source.split('.')[2];
     if (!otherAssignedSourceInRoom(source)) {

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -127,9 +127,9 @@ export function calculateRemoteSourceStats(source: string, roomName: string, ign
         road: roadStats.road,
     };
 
-    for (let [key, value] of Object.entries(stats)) {
-        if (key !== 'road') console.log(`${key}: ${value}`);
-    }
+    // for (let [key, value] of Object.entries(stats)) {
+    //     if (key !== 'road') console.log(`${key}: ${value}`);
+    // }
 
     return stats;
 }

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -309,7 +309,7 @@ export function findSuitableRemoteSource(roomName: string, noKeeperRooms: boolea
     options = options.filter((option) => option.stats.estimatedIncome / option.stats.gathererCount >= 750);
 
     //prefer central rooms over other rooms and prefer closer to farther
-    options.reduce((highest, next) => next.stats.estimatedIncome > highest.stats.estimatedIncome ? next : highest);
+    options.sort((a,b) => b.stats.estimatedIncome - a.stats.estimatedIncome);
 
     return options.shift();
 }

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -1,15 +1,20 @@
+import { isCenterRoom, isKeeperRoom } from './data';
 import { getStoragePos } from './roomDesign';
 
-export function calculateRemoteSourceCost(sourcePos: RoomPosition, room: Room) {
+//Calculate maintenance cost of road to source per road decay cycle. Considers pre-existing roads in homeroom and roomData to be .5 cost of plains. Doesn't consider travel wear
+export function calculateRoadStats(
+    sourcePos: RoomPosition,
+    room: Room,
+    ignoreRoomDataRoads = false
+): { roadLength: number; maintenanceCost: number } {
     let storagePos = getStoragePos(room);
-    console.log(storagePos);
 
     const path = PathFinder.search(
         storagePos,
         { pos: sourcePos, range: 1 },
         {
-            plainCost: 2,
-            swampCost: 10,
+            plainCost: (2 * ROAD_DECAY_AMOUNT) / REPAIR_POWER,
+            swampCost: (2 * ROAD_DECAY_AMOUNT * 5) / REPAIR_POWER,
             roomCallback: (roomName: string) => {
                 if (
                     roomName !== room.name &&
@@ -21,20 +26,23 @@ export function calculateRemoteSourceCost(sourcePos: RoomPosition, room: Room) {
                 }
 
                 let matrix = new PathFinder.CostMatrix();
-                let roads = Memory.roomData[roomName]?.roads ? Object.values(Memory.roomData[roomName].roads) : [];
-                if (roads?.length) {
-                    roads.forEach((road) =>
-                        road.split(',').forEach((posString) => {
-                            let split = posString.split(':').map((v) => parseInt(v));
-                            matrix.set(split[0], split[1], 1);
-                        })
-                    );
-                }
 
                 if (roomName === room.name) {
                     room.stamps?.road.forEach((r) => {
                         if (r.rcl <= room.controller.level) matrix.set(r.pos.x, r.pos.y, 1);
                     });
+                }
+
+                if (!ignoreRoomDataRoads) {
+                    let roads = Memory.roomData[roomName]?.roads ? Object.values(Memory.roomData[roomName].roads) : [];
+                    if (roads?.length) {
+                        roads.forEach((road) =>
+                            road.split(',').forEach((posString) => {
+                                let split = posString.split(':').map((v) => parseInt(v));
+                                matrix.set(split[0], split[1], 1);
+                            })
+                        );
+                    }
                 }
 
                 return matrix;
@@ -44,8 +52,83 @@ export function calculateRemoteSourceCost(sourcePos: RoomPosition, room: Room) {
     );
 
     if (path.incomplete) {
-        return ERR_NOT_IN_RANGE;
+        return { roadLength: -1, maintenanceCost: -1 };
     }
 
-    return path.cost;
+    let visualRooms = Array.from(new Set(path.path.map((pos) => pos.roomName)));
+    visualRooms.forEach((r) => {
+        let rv = new RoomVisual(r);
+        rv.poly(path.path.filter((p) => p.roomName === r));
+    });
+
+    const MAINTENANCE_COST = path.cost / 2; //the cost matrix values for plains and swamp are 5x the decay value to prioritize pre-existing roads.
+    const MAINTENANCE_COST_PER_CYCLE = (MAINTENANCE_COST / ROAD_DECAY_TIME) * ENERGY_REGEN_TIME; //roads decay every 1k ticks, whereas sources regen every 300
+    return { roadLength: path.path.length, maintenanceCost: MAINTENANCE_COST_PER_CYCLE };
+}
+
+export function calculateRemoteSourceStats(sourcePos: RoomPosition, room: Room, ignoreRoomDataRoads = false) {
+    //Energy output of source per regen cycle
+    const SOURCE_OUTPUT_PER_CYCLE =
+        isKeeperRoom(sourcePos.roomName) || isCenterRoom(sourcePos.roomName) ? SOURCE_ENERGY_KEEPER_CAPACITY : SOURCE_ENERGY_CAPACITY;
+
+    const roadStats = calculateRoadStats(sourcePos, room, ignoreRoomDataRoads);
+
+    //Cost of road maintenance per source regen cycle
+    const ROAD_MAINTENANCE_PER_CYCLE = roadStats.maintenanceCost;
+
+    //cost of miner production per regen cycle
+    const MINER_WORK_NEEDED = Math.ceil(SOURCE_OUTPUT_PER_CYCLE / HARVEST_POWER / ENERGY_REGEN_TIME) + 1; //+1 because miner needs to repair container
+    const MINER_MOVE_NEEDED = Math.ceil((MINER_WORK_NEEDED + 1) / 2);
+    const MINER_COST_PER_CYCLE =
+        ((BODYPART_COST[CARRY] + MINER_WORK_NEEDED * BODYPART_COST[WORK] + MINER_MOVE_NEEDED * BODYPART_COST[MOVE]) / CREEP_LIFE_TIME) *
+        ENERGY_REGEN_TIME;
+
+    //cost of gatherer production per regen cycle
+    //Ideally, gatherer will move all the energy from miner container to storage before it fills up.
+    const CONTAINER_FILL_RATE = MINER_WORK_NEEDED * HARVEST_POWER;
+    const TICKS_TO_FILL_CONTAINER = Math.ceil(CONTAINER_CAPACITY / CONTAINER_FILL_RATE);
+    const CONTAINER_MAINTENANCE_PER_CYCLE = (CONTAINER_DECAY / REPAIR_POWER / CONTAINER_DECAY_TIME) * ENERGY_REGEN_TIME; //should be 150
+
+    const MAX_GATHERER_CAPACITY = 1900;
+
+    const ROAD_LENGTH = roadStats.roadLength;
+    const GATHERER_TRIP_DURATION = ROAD_LENGTH * 3; //takes 3x the road length to make it back to storage (2 ticks per step to storage, 1 tick per step on return), so maximum road length allowed for ONE gatherer to do the job is 100
+
+    //if the trip can't be completed before the container fills again, we'll need more than one gatherer for max efficiency
+    const GATHERERS_NEEDED = Math.ceil(GATHERER_TRIP_DURATION / TICKS_TO_FILL_CONTAINER);
+
+    const GATHERER_WORK_NEEDED = 2;
+    const GATHERER_CARRY_NEEDED = 38;
+    const GATHERER_MOVE_NEEDED = 10;
+    const GATHERER_COST_PER_CYCLE =
+        ((GATHERER_WORK_NEEDED * BODYPART_COST[WORK] + GATHERER_CARRY_NEEDED * BODYPART_COST[CARRY] + GATHERER_MOVE_NEEDED * BODYPART_COST[MOVE]) /
+            CREEP_LIFE_TIME) *
+        ENERGY_REGEN_TIME;
+
+    const RESERVER_COST_PER_CYCLE = ((BODYPART_COST[CLAIM] + BODYPART_COST[MOVE]) / CREEP_CLAIM_LIFE_TIME) * ENERGY_REGEN_TIME;
+
+    const TOTAL_COSTS_PER_CYCLE =
+        MINER_COST_PER_CYCLE +
+        GATHERERS_NEEDED * GATHERER_COST_PER_CYCLE +
+        RESERVER_COST_PER_CYCLE +
+        CONTAINER_MAINTENANCE_PER_CYCLE +
+        ROAD_MAINTENANCE_PER_CYCLE;
+    const NET_INCOME_PER_CYCLE = SOURCE_OUTPUT_PER_CYCLE - TOTAL_COSTS_PER_CYCLE;
+
+    let stats = {
+        netIncome: NET_INCOME_PER_CYCLE,
+        roadLength: ROAD_LENGTH,
+        roadMaintenance: ROAD_MAINTENANCE_PER_CYCLE,
+        containerMaintenance: CONTAINER_MAINTENANCE_PER_CYCLE,
+        minerUpkeep: MINER_COST_PER_CYCLE,
+        gathererCount: GATHERERS_NEEDED,
+        gathererUpkeep: GATHERER_COST_PER_CYCLE,
+        reserverUpkeep: RESERVER_COST_PER_CYCLE,
+    };
+
+    for (let [key, value] of Object.entries(stats)) {
+        console.log(`${key}: ${value}`);
+    }
+
+    return stats;
 }

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -134,10 +134,10 @@ function createKeeperLairData(remoteRoomName: string): { [id: Id<Source> | Id<Mi
         .forEach((lair) => {
             const source = lair.pos.findClosestByRange(FIND_SOURCES);
             if (lair.pos.getRangeTo(source) < 6) {
-                lairs[source.id] = lair.id;
+                lairs[source.pos.toMemSafe()] = lair.id;
             } else {
                 const mineral = lair.pos.findClosestByRange(FIND_MINERALS);
-                lairs[mineral.id] = lair.id;
+                lairs[mineral.pos.toMemSafe()] = lair.id;
             }
         });
     return lairs;

--- a/src/modules/remoteRoomManagement.ts
+++ b/src/modules/remoteRoomManagement.ts
@@ -5,7 +5,7 @@ import { PopulationManagement } from './populationManagement';
 export function manageRemoteRoom(controllingRoomName: string, remoteRoomName: string) {
     let remoteRoom = Game.rooms[remoteRoomName];
     if (remoteRoom) {
-        if(isKeeperRoom(remoteRoomName) && !Memory.remoteData[remoteRoomName].sourceKeeperLairs){
+        if (isKeeperRoom(remoteRoomName) && !Memory.remoteData[remoteRoomName].sourceKeeperLairs) {
             Memory.remoteData[remoteRoomName].sourceKeeperLairs = createKeeperLairData(remoteRoomName);
         }
         Memory.remoteData[remoteRoomName].threatLevel = monitorThreatLevel(remoteRoom);
@@ -175,7 +175,7 @@ function reassignIdleProtector(controllingRoomName: string, remoteRoomName: stri
     return false;
 }
 
-export function removeRemoteRoom(hostName: string, remoteRoomName: string) {
+export function removeRemoteRoomMemory(remoteRoomName: string) {
     delete Memory.remoteData[remoteRoomName];
     Memory.roomData[remoteRoomName].asOf = Game.time;
     Memory.roomData[remoteRoomName].roomStatus = RoomMemoryStatus.VACANT;

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -91,7 +91,7 @@ export function manageEmpireResources() {
                 }
 
                 let extraResources = getExtraResources(room);
-                if (extraResources.length) {
+                if (extraResources.length && room.energyStatus >= EnergyStatus.STABLE) {
                     let sent = false;
                     extraResources.forEach((resource) => {
                         let roomsInNeed = global.resourceNeeds[resource];

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -31,9 +31,12 @@ export function getRoad(startPos: RoomPosition, endPos: RoomPosition, opts?: Roa
 
             if (Memory.remoteData[roomName]) {
                 let miningRoomsWithPos = Object.entries(Memory.remoteSourceAssignments).filter(
-                    ([source, miningRoom]) => source.split('.')[2] === roomName
+                    ([source, miningData]) => source.split('.')[2] === roomName
                 );
-                let miningPositions = miningRoomsWithPos.map(([source, room]) => Memory.rooms[room].remoteSources[source].miningPos);
+                let miningPositions = miningRoomsWithPos.map(([source, miningData]) => {
+                    let miningPos = Memory.rooms[miningData.controllingRoom].remoteSources[source].miningPos;
+                    return miningPos;
+                });
                 miningPositions.forEach((pos) => matrix.set(pos.toRoomPos().x, pos.toRoomPos().y, 255));
             }
 
@@ -178,9 +181,9 @@ export function getFullRoad(roadKey: string): RoomPosition[] {
 
     let road = decodeRoad(roadCode, startingRoomName);
     const segments = getRoadSegments(road);
-    if(segments.length > 1){
+    if (segments.length > 1) {
         road = segments[0];
-    } 
+    }
 
     let nextRoomName = Game.map.describeExits(startingRoomName)[getExitDirection(road[road.length - 1])];
     if (nextRoomName !== ERR_INVALID_ARGS) {
@@ -199,14 +202,12 @@ function recursiveRoadGet(roadKey: string, roomName: string, lastPos: RoomPositi
 
     let road = decodeRoad(roadCode, roomName);
     let segments = getRoadSegments(road);
-    
-    if(segments.length > 1){
-        let currentSegment = segments.find(seg => 
-            (Math.abs(seg[0].x - lastPos.x) <= 1 || Math.abs(seg[0].y - lastPos.y) <= 1)
-        );
+
+    if (segments.length > 1) {
+        let currentSegment = segments.find((seg) => Math.abs(seg[0].x - lastPos.x) <= 1 || Math.abs(seg[0].y - lastPos.y) <= 1);
         road = currentSegment;
-    } 
-    
+    }
+
     let destination = roadKey.split(':')[1].toRoomPos();
 
     if (road[road.length - 1].isNearTo(destination)) {
@@ -265,8 +266,11 @@ export function getRoadPathFromPos(roadKey: string, startPos: RoomPosition, dest
 }
 
 export function roadCodeContainsMultipleSegments(roadCode: string): boolean {
-    for(let i = 2; i < roadCode.length; i += 2){
-        if((Math.abs(MAPPING.indexOf(roadCode[i-2]) - MAPPING.indexOf(roadCode[i])) > 1) || Math.abs(MAPPING.indexOf(roadCode[i-1]) - MAPPING.indexOf(roadCode[i+1])) > 1){
+    for (let i = 2; i < roadCode.length; i += 2) {
+        if (
+            Math.abs(MAPPING.indexOf(roadCode[i - 2]) - MAPPING.indexOf(roadCode[i])) > 1 ||
+            Math.abs(MAPPING.indexOf(roadCode[i - 1]) - MAPPING.indexOf(roadCode[i + 1])) > 1
+        ) {
             return true;
         }
     }

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -1,4 +1,4 @@
-import { getBunkerPositions, getStructureForPos } from './roomDesign';
+import { getBunkerPositions, getStructureForPos } from './data';
 
 const MAPPING = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
@@ -212,4 +212,20 @@ export function roadIsSafe(roadKey: string) {
 export function deleteRoad(roadKey: string) {
     let roadRooms = Object.keys(Memory.roomData).filter((room) => Memory.roomData[room]?.roads?.[roadKey]);
     roadRooms.forEach((room) => delete Memory.roomData[room].roads[roadKey]);
+}
+
+export function getRoadPathFromPos(roadKey: string, startPos: RoomPosition, destination: string): RoomPosition[] {
+    const fullRoad = getFullRoad(roadKey);
+    const startPosIndex = fullRoad.findIndex((pos) => pos.isEqualTo(startPos));
+    const direction = roadKey.split(':')[0] === destination ? -1 : 1;
+
+    let path: RoomPosition[] = [];
+
+    if (direction === 1) {
+        path = fullRoad.slice(startPosIndex);
+    } else {
+        path = fullRoad.slice(0, startPosIndex).reverse();
+    }
+
+    return path;
 }

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -1,90 +1,88 @@
-import { getAllRoomNeeds } from "./resourceManagement";
-import { getBunkerPositions, getStructureForPos } from "./roomDesign";
+import { getBunkerPositions, getStructureForPos } from './roomDesign';
 
 const MAPPING = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 export function getRoad(startPos: RoomPosition, endPos: RoomPosition, opts?: RoadOpts): PathFinderPath {
-
-    if(opts === undefined){
+    if (opts === undefined) {
         opts = {};
     }
 
-    if(opts?.allowedStatuses === undefined){
+    if (opts?.allowedStatuses === undefined) {
         opts.allowedStatuses = [RoomMemoryStatus.RESERVED_ME, RoomMemoryStatus.RESERVED_INVADER, RoomMemoryStatus.VACANT, RoomMemoryStatus.OWNED_ME];
     }
 
-    if(opts?.ignoreOtherRoads === undefined){
+    if (opts?.ignoreOtherRoads === undefined) {
         opts.ignoreOtherRoads = false;
     }
 
-    const pathSearch = PathFinder.search(
-        startPos,
-        opts.destRange ? {range: opts.destRange, pos: endPos} : endPos,
-        {
-            plainCost: (2 * ROAD_DECAY_AMOUNT) / REPAIR_POWER,
-            swampCost: (2 * ROAD_DECAY_AMOUNT * 5) / REPAIR_POWER,
-            roomCallback: (roomName: string) => {
-                if (
-                    roomName !== startPos.roomName &&
-                    roomName !== endPos.roomName &&
-                    !opts.allowedStatuses.includes(
-                        Memory.roomData[roomName]?.roomStatus
-                    )
-                ) {
-                    return false;
+    const pathSearch = PathFinder.search(startPos, opts.destRange ? { range: opts.destRange, pos: endPos } : endPos, {
+        plainCost: (2 * ROAD_DECAY_AMOUNT) / REPAIR_POWER,
+        swampCost: (2 * ROAD_DECAY_AMOUNT * 5) / REPAIR_POWER,
+        roomCallback: (roomName: string) => {
+            if (
+                roomName !== startPos.roomName &&
+                roomName !== endPos.roomName &&
+                !opts.allowedStatuses.includes(Memory.roomData[roomName]?.roomStatus)
+            ) {
+                return false;
+            }
+
+            let matrix = new PathFinder.CostMatrix();
+
+            if (Memory.roomData[roomName]?.roomStatus === RoomMemoryStatus.OWNED_ME) {
+                if (Memory.rooms[roomName].layout === RoomLayout.BUNKER) {
+                    getBunkerPositions(Game.rooms[roomName]).forEach((pos) =>
+                        matrix.set(
+                            pos.x,
+                            pos.y,
+                            getStructureForPos(RoomLayout.BUNKER, pos, Memory.rooms[roomName].anchorPoint.toRoomPos()) === STRUCTURE_ROAD ? 1 : 255
+                        )
+                    );
+                } else if (Memory.rooms[roomName].layout === RoomLayout.STAMP) {
+                    Object.entries(Game.rooms[roomName].stamps).forEach(([key, stampsDetails]: [string, StampDetail[]]) =>
+                        stampsDetails.forEach((detail) => matrix.set(detail.pos.x, detail.pos.y, key === 'road' || key === 'rampart' ? 1 : 255))
+                    );
                 }
+            }
 
-                let matrix = new PathFinder.CostMatrix();
-
-                if (Memory.roomData[roomName]?.roomStatus === RoomMemoryStatus.OWNED_ME) {
-                    if(Memory.rooms[roomName].layout === RoomLayout.BUNKER){
-                        getBunkerPositions(Game.rooms[roomName]).forEach(pos => matrix.set(pos.x, pos.y, getStructureForPos(RoomLayout.BUNKER, pos, Memory.rooms[roomName].anchorPoint.toRoomPos()) === STRUCTURE_ROAD ? 1 : 255));
-                    } else if (Memory.rooms[roomName].layout === RoomLayout.STAMP){
-                        Object.entries(Game.rooms[roomName].stamps).forEach(([key, stampsDetails]: [string, StampDetail[]]) =>
-                            stampsDetails.forEach(detail => matrix.set(detail.pos.x, detail.pos.y, key === 'road' || key === 'rampart' ? 1 : 255))
-                        );
-                    }
+            if (!opts.ignoreOtherRoads) {
+                let otherRoadKeys = Object.keys(Memory.roomData[roomName]?.roads).filter((k) => k !== `${startPos}:${endPos}`);
+                let roads = otherRoadKeys?.map((key) => Memory.roomData[roomName].roads[key]);
+                if (roads?.length) {
+                    roads.forEach((roadCode) => {
+                        try {
+                            decodeRoad(roadCode, roomName).forEach((pos) => matrix.set(pos.x, pos.y, 1));
+                        } catch (e) {
+                            console.log('error decoding road: ' + roadCode + ' : ' + roomName);
+                        }
+                    });
                 }
+            }
 
-                if (!opts.ignoreOtherRoads) {
-                    let roads = Memory.roomData[roomName]?.roads ? Object.values(Memory.roomData[roomName].roads) : [];
-                    if (roads?.length) {
-                        roads.forEach(roadCode => {
-                            try{
-                                decodeRoad(roadCode, roomName).forEach(pos => matrix.set(pos.x, pos.y, 1))
-                            } catch (e){
-                                console.log("error decoding road: " + roadCode + " : " + roomName);
-                            }
-                        });
-                    }
-                }
-
-                return matrix;
-            },
-            maxOps: 10000,
-        }
-    );
+            return matrix;
+        },
+        maxOps: 10000,
+    });
 
     return pathSearch;
 }
 
-export function storeRoadInMemory(startPos: RoomPosition, endPos: RoomPosition, road: RoomPosition[]): ScreepsReturnCode{
-    if(!startPos || !endPos || !road || !road.length){
+export function storeRoadInMemory(startPos: RoomPosition, endPos: RoomPosition, road: RoomPosition[]): ScreepsReturnCode {
+    if (!startPos || !endPos || !road || !road.length) {
         return ERR_INVALID_ARGS;
     }
-    
-    const roadKey = `${startPos.toMemSafe()}:${endPos.toMemSafe()}`;
-    
-    try{
-        const encodedRoadSegments = encodeRoad(road);
-        encodedRoadSegments.forEach(segment => {
 
-            if(!Memory.roomData[segment.roomName].roads){
+    const roadKey = `${startPos.toMemSafe()}:${endPos.toMemSafe()}`;
+
+    try {
+        const encodedRoadSegments = encodeRoad(road);
+        encodedRoadSegments.forEach((segment) => {
+            if (!Memory.roomData[segment.roomName].roads) {
                 Memory.roomData[segment.roomName].roads = {};
             }
 
             Memory.roomData[segment.roomName].roads[roadKey] = segment.roadCode;
-        })
+        });
     } catch (e) {
         console.log(`Error encoding road: ${startPos}:${endPos}`);
         return ERR_INVALID_ARGS;
@@ -94,76 +92,75 @@ export function storeRoadInMemory(startPos: RoomPosition, endPos: RoomPosition, 
 }
 
 //decode a road for a given room
-export function decodeRoad(roadString: string, roomName: string): RoomPosition[]{
+export function decodeRoad(roadString: string, roomName: string): RoomPosition[] {
     let arr = [];
-    for(let i = 0; i < roadString.length; i += 2){
-        arr.push(new RoomPosition(decode(roadString.charAt(i)), decode(roadString.charAt(i+1)), roomName));
+    for (let i = 0; i < roadString.length; i += 2) {
+        arr.push(new RoomPosition(decode(roadString.charAt(i)), decode(roadString.charAt(i + 1)), roomName));
     }
     return arr;
 }
 
 //takes in a single path, and returns an array of codes mapped to their room names
-function encodeRoad(road: RoomPosition[]): {roomName: string, roadCode: string}[] {
+function encodeRoad(road: RoomPosition[]): { roomName: string; roadCode: string }[] {
     let roadCodes = [];
 
-    const pathRooms = Array.from(new Set(road.map(pos => pos.roomName)));
-    pathRooms.forEach(roomName => {
+    const pathRooms = Array.from(new Set(road.map((pos) => pos.roomName)));
+    pathRooms.forEach((roomName) => {
         let roadCode = '';
-        road.filter(step => step.roomName === roomName).forEach(step => {
-            
+        road.filter((step) => step.roomName === roomName).forEach((step) => {
             let stepCode = encode(step.x) + encode(step.y);
             roadCode += stepCode;
         });
-        roadCodes.push({roomName: roomName, roadCode: roadCode});
+        roadCodes.push({ roomName: roomName, roadCode: roadCode });
     });
 
     return roadCodes;
 }
 
 //separate road into contiguous segments
-export function getRoadSegments(road: RoomPosition[]): RoomPosition[][]{
+export function getRoadSegments(road: RoomPosition[]): RoomPosition[][] {
     let startingIndices = [0];
     let segments = [];
-    for(let i = 1; i < road.length; i++){
-        if (!road[i].isNearTo(road[i-1])){
+    for (let i = 1; i < road.length; i++) {
+        if (!road[i].isNearTo(road[i - 1])) {
             startingIndices.push(i);
         }
     }
 
-    for(let i = 0; i < startingIndices.length; i++){
-        if(i === startingIndices.length - 1){
+    for (let i = 0; i < startingIndices.length; i++) {
+        if (i === startingIndices.length - 1) {
             segments.push(road.slice(startingIndices[i]));
         } else {
-            segments.push(road.slice(startingIndices[i], startingIndices[i+1]));
+            segments.push(road.slice(startingIndices[i], startingIndices[i + 1]));
         }
     }
 
     return segments;
 }
 
-function decode(char: string): number{
+function decode(char: string): number {
     return MAPPING.indexOf(char);
 }
 
-function encode(int: number): string{
+function encode(int: number): string {
     return MAPPING.charAt(int);
 }
 
-export function posExistsOnRoad(pos: RoomPosition): boolean{
-    let roads = Object.values(Memory.roomData[pos.roomName].roads).map(roadCode => decodeRoad(roadCode, pos.roomName));
+export function posExistsOnRoad(pos: RoomPosition): boolean {
+    let roads = Object.values(Memory.roomData[pos.roomName].roads).map((roadCode) => decodeRoad(roadCode, pos.roomName));
 
-    return roads.some(road => road.some(roadPos => roadPos.isEqualTo(pos)));
+    return roads.some((road) => road.some((roadPos) => roadPos.isEqualTo(pos)));
 }
 
 //trace a road through all rooms from starting point to return RoomPosition array
-export function getFullRoad(roadKey: string): RoomPosition[]{
+export function getFullRoad(roadKey: string): RoomPosition[] {
     let startingRoomName = roadKey.split(':')[0].toRoomPos().roomName;
     return recursiveRoadGet(roadKey, startingRoomName);
 }
 
-function recursiveRoadGet(roadKey: string, roomName: string): RoomPosition[]{
+function recursiveRoadGet(roadKey: string, roomName: string): RoomPosition[] {
     const roadCode = Memory.roomData[roomName]?.roads[roadKey];
-    if(!roadCode){
+    if (!roadCode) {
         console.log(`Error tracing road ${roadKey} through ${roomName}`);
         return [];
     }
@@ -172,40 +169,41 @@ function recursiveRoadGet(roadKey: string, roomName: string): RoomPosition[]{
 
     let destination = roadKey.split(':')[1].toRoomPos();
 
-    if(road[road.length-1].isNearTo(destination)){
+    if (road[road.length - 1].isNearTo(destination)) {
         return road;
     } else {
-        let nextRoomName = Game.map.describeExits(roomName)[getExitDirection(road[road.length-1])];
-        if(nextRoomName !== ERR_INVALID_ARGS){
-            return [...road,...recursiveRoadGet(roadKey, nextRoomName)];
+        let nextRoomName = Game.map.describeExits(roomName)[getExitDirection(road[road.length - 1])];
+        if (nextRoomName !== ERR_INVALID_ARGS) {
+            return [...road, ...recursiveRoadGet(roadKey, nextRoomName)];
         } else {
             return undefined;
         }
     }
 }
 
-function getExitDirection(exitPos: RoomPosition) : DirectionConstant | ScreepsReturnCode{
-    return exitPos.x === 0 ? LEFT 
-        : exitPos.x === 49 ? RIGHT
-        : exitPos.y === 0 ? TOP
-        : exitPos.y === 49 ? BOTTOM
-        : ERR_INVALID_ARGS;
+function getExitDirection(exitPos: RoomPosition): DirectionConstant | ScreepsReturnCode {
+    return exitPos.x === 0 ? LEFT : exitPos.x === 49 ? RIGHT : exitPos.y === 0 ? TOP : exitPos.y === 49 ? BOTTOM : ERR_INVALID_ARGS;
 }
 
-export function getAllRoadRooms(roadKey: string): string[]{
-    return Array.from(new Set(getFullRoad(roadKey).map(pos => pos.roomName)));
+export function getAllRoadRooms(roadKey: string): string[] {
+    return Array.from(new Set(getFullRoad(roadKey).map((pos) => pos.roomName)));
 }
 
 export function roadIsPaved(roadKey: string): boolean | ScreepsReturnCode {
     let road = getFullRoad(roadKey);
-    let canSeeAllRooms = road.every(pos => Game.rooms[pos.roomName]);
-    if(canSeeAllRooms) {
-        return road.every(pos => pos.lookFor(LOOK_STRUCTURES).some(structure => structure.structureType === STRUCTURE_ROAD));
+    let canSeeAllRooms = road.every((pos) => Game.rooms[pos.roomName]);
+    if (canSeeAllRooms) {
+        return road.every((pos) => pos.lookFor(LOOK_STRUCTURES).some((structure) => structure.structureType === STRUCTURE_ROAD));
     } else {
         return ERR_NOT_FOUND;
     }
 }
 
-export function roadIsSafe(roadKey: string){
-    return getAllRoadRooms(roadKey).every(room => Memory.roomData[room]?.hostile !== true);
+export function roadIsSafe(roadKey: string) {
+    return getAllRoadRooms(roadKey).every((room) => Memory.roomData[room]?.hostile !== true);
+}
+
+export function deleteRoad(roadKey: string) {
+    let roadRooms = Object.keys(Memory.roomData).filter((room) => Memory.roomData[room]?.roads?.[roadKey]);
+    roadRooms.forEach((room) => delete Memory.roomData[room].roads[roadKey]);
 }

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -241,7 +241,11 @@ export function roadIsPaved(roadKey: string): boolean | ScreepsReturnCode {
 }
 
 export function roadIsSafe(roadKey: string) {
-    return getAllRoadRooms(roadKey).every((room) => Memory.roomData[room]?.hostile !== true);
+    return getAllRoadRooms(roadKey).every(
+        (room) =>
+            (Memory.roomData[room]?.hostile !== true && !Memory.remoteData[room]) ||
+            Memory.remoteData[room].threatLevel < RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS
+    );
 }
 
 export function deleteRoad(roadKey: string) {

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -95,7 +95,12 @@ export function storeRoadInMemory(startPos: RoomPosition, endPos: RoomPosition, 
 export function decodeRoad(roadString: string, roomName: string): RoomPosition[] {
     let arr = [];
     for (let i = 0; i < roadString.length; i += 2) {
-        arr.push(new RoomPosition(decode(roadString.charAt(i)), decode(roadString.charAt(i + 1)), roomName));
+        try {
+            arr.push(new RoomPosition(decode(roadString.charAt(i)), decode(roadString.charAt(i + 1)), roomName));
+        } catch (e) {
+            console.log(`Error decoding road: ${roadString} - ${e}`);
+            console.log(`${roadString.charAt(i)}${roadString.charAt(i + 1)} => ${decode(roadString.charAt(i))}.${decode(roadString.charAt(i + 1))}`);
+        }
     }
     return arr;
 }
@@ -222,7 +227,7 @@ export function getRoadPathFromPos(roadKey: string, startPos: RoomPosition, dest
     let path: RoomPosition[] = [];
 
     if (direction === 1) {
-        path = fullRoad.slice(startPosIndex);
+        path = fullRoad.slice(startPosIndex + 1);
     } else {
         path = fullRoad.slice(0, startPosIndex).reverse();
     }

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -146,10 +146,16 @@ function encode(int: number): string {
     return MAPPING.charAt(int);
 }
 
-export function posExistsOnRoad(pos: RoomPosition): boolean {
-    let roads = Object.values(Memory.roomData[pos.roomName].roads).map((roadCode) => decodeRoad(roadCode, pos.roomName));
+//checks certain road for pos. If no road provided, checks all roads in room
+export function posExistsOnRoad(pos: RoomPosition, roadKey?: string): boolean {
+    if (!Memory.roomData[pos.roomName]?.roads) {
+        return false;
+    }
+    let roadPositions: RoomPosition[] = roadKey
+        ? decodeRoad(Memory.roomData[pos.roomName].roads[roadKey], pos.roomName)
+        : _.flatten(Object.values(Memory.roomData[pos.roomName].roads).map((roadCode) => decodeRoad(roadCode, pos.roomName)));
 
-    return roads.some((road) => road.some((roadPos) => roadPos.isEqualTo(pos)));
+    return roadPositions.some((roadPos) => roadPos.isEqualTo(pos));
 }
 
 //trace a road through all rooms from starting point to return RoomPosition array

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -29,6 +29,14 @@ export function getRoad(startPos: RoomPosition, endPos: RoomPosition, opts?: Roa
 
             let matrix = new PathFinder.CostMatrix();
 
+            if (Memory.remoteData[roomName]) {
+                let miningRoomsWithPos = Object.entries(Memory.remoteSourceAssignments).filter(
+                    ([source, miningRoom]) => source.split('.')[2] === roomName
+                );
+                let miningPositions = miningRoomsWithPos.map(([source, room]) => Memory.rooms[room].remoteSources[source].miningPos);
+                miningPositions.forEach((pos) => matrix.set(pos.toRoomPos().x, pos.toRoomPos().y, 255));
+            }
+
             if (Memory.roomData[roomName]?.roomStatus === RoomMemoryStatus.OWNED_ME) {
                 if (Memory.rooms[roomName].layout === RoomLayout.BUNKER) {
                     getBunkerPositions(Game.rooms[roomName]).forEach((pos) =>

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -45,10 +45,10 @@ export function getRoad(startPos: RoomPosition, endPos: RoomPosition, opts?: Roa
                 }
             }
 
-            if (!opts.ignoreOtherRoads) {
-                let otherRoadKeys = Object.keys(Memory.roomData[roomName]?.roads).filter((k) => k !== `${startPos}:${endPos}`);
-                let roads = otherRoadKeys?.map((key) => Memory.roomData[roomName].roads[key]);
-                if (roads?.length) {
+            if (!opts.ignoreOtherRoads && Memory.roomData[roomName]?.roads) {
+                let otherRoadKeys = Object.keys(Memory.roomData[roomName].roads).filter((k) => k !== `${startPos}:${endPos}`);
+                let roads = otherRoadKeys.map((key) => Memory.roomData[roomName].roads[key]);
+                if (roads.length) {
                     roads.forEach((roadCode) => {
                         try {
                             decodeRoad(roadCode, roomName).forEach((pos) => matrix.set(pos.x, pos.y, 1));

--- a/src/modules/roomDesign.ts
+++ b/src/modules/roomDesign.ts
@@ -1,3 +1,4 @@
+import { getStructureForPos } from './data';
 import { Pathing } from './pathing';
 
 export function calculateRoomSpace(room: Room) {
@@ -102,85 +103,6 @@ export function drawBunker(anchorPoint: RoomPosition) {
     roomVis.rect(anchorPoint.x - 6 - 0.5, anchorPoint.y - 6 - 0.5, 13, 13, { fill: '#00E2FF', opacity: 0.1 });
 }
 
-export function getStructureForPos(layout: RoomLayout, targetPos: RoomPosition, anchorPoint: RoomPosition): BuildableStructureConstant {
-    switch (layout) {
-        case RoomLayout.BUNKER:
-            let xdif = targetPos.x - anchorPoint.x;
-            let ydif = targetPos.y - anchorPoint.y;
-
-            if (targetPos === anchorPoint || Math.abs(xdif) >= 7 || Math.abs(ydif) >= 7) {
-                return undefined;
-            }
-
-            if (xdif === 0) {
-                switch (ydif) {
-                    case 1:
-                        return STRUCTURE_TERMINAL;
-                    case -1:
-                        return STRUCTURE_SPAWN;
-                    case -2:
-                    case 2:
-                    case -6:
-                    case 6:
-                        return STRUCTURE_EXTENSION;
-                    default:
-                        return STRUCTURE_ROAD;
-                }
-            }
-
-            if (ydif === 0) {
-                switch (xdif) {
-                    case -2:
-                        return STRUCTURE_OBSERVER;
-                    case -1:
-                        return STRUCTURE_LINK;
-                    case 1:
-                        return STRUCTURE_FACTORY;
-                    case 2:
-                        return STRUCTURE_SPAWN;
-                    default:
-                        return STRUCTURE_ROAD;
-                }
-            }
-
-            if (Math.abs(xdif) === 6 || Math.abs(ydif) === 6) {
-                return STRUCTURE_ROAD;
-            }
-
-            if (ydif === -1 && xdif === -1) {
-                return STRUCTURE_SPAWN;
-            }
-            if (ydif === -1 && xdif === 1) {
-                return STRUCTURE_STORAGE;
-            }
-            if (ydif === 1 && xdif === 1) {
-                return STRUCTURE_POWER_SPAWN;
-            }
-            if (ydif === 1 && xdif === -1) {
-                return STRUCTURE_NUKER;
-            }
-
-            if (Math.abs(ydif) === Math.abs(xdif) && Math.abs(ydif) <= 5) {
-                return STRUCTURE_ROAD;
-            }
-            if ((ydif === -3 && xdif >= -1 && xdif <= 2) || (xdif === 3 && ydif >= -2 && ydif <= 1)) {
-                return STRUCTURE_TOWER;
-            }
-            if (ydif <= -2 && ydif >= -5 && xdif <= -3 && xdif >= -4) {
-                return STRUCTURE_LAB;
-            }
-            if (ydif <= -3 && ydif >= -4 && (xdif === -2 || xdif === -5)) {
-                return STRUCTURE_LAB;
-            }
-
-            if ((Math.abs(ydif) === 2 && Math.abs(xdif) === 1) || (Math.abs(xdif) === 2 && Math.abs(ydif) === 1)) {
-                return STRUCTURE_ROAD;
-            }
-
-            return STRUCTURE_EXTENSION;
-    }
-}
-
 export function getSpawnPos(room: Room) {
     switch (room.memory.layout) {
         case RoomLayout.BUNKER:
@@ -188,19 +110,6 @@ export function getSpawnPos(room: Room) {
             return new RoomPosition(anchorPoint.x, anchorPoint.y - 1, room.name);
         case RoomLayout.STAMP:
             return room.stamps.spawn.find((spawnStamp) => spawnStamp.rcl === 1).pos;
-    }
-}
-
-export function getBunkerPositions(room: Room): RoomPosition[]{
-    if(room.memory.anchorPoint){
-        let anchor = room.memory.anchorPoint.toRoomPos();
-        let posArr = [];
-        for(let i = -6; i < 7; i++){
-            for (let j = -6; j < 7; j++){
-                posArr.push(room.getPositionAt(anchor.x + i, anchor.y + j));
-            }
-        }
-        return posArr;
     }
 }
 
@@ -487,13 +396,15 @@ export function roomNeedsCoreStructures(room: Room) {
     let labCount = roomStructures.filter((structure) => structure.structureType === STRUCTURE_LAB).length;
     let towerCount = roomStructures.filter((structure) => structure.structureType === STRUCTURE_TOWER).length;
     let managerLink =
-        room.memory.anchorPoint?.toRoomPos() || room.memory.managerPos?.toRoomPos()
+        room.memory.anchorPoint?.toRoomPos() ||
+        room.memory.managerPos
+            ?.toRoomPos()
             ?.findInRange(FIND_MY_STRUCTURES, 1)
             .filter((s) => s.structureType === STRUCTURE_LINK).length +
             (room.memory.anchorPoint?.toRoomPos() || room.memory.managerPos?.toRoomPos())
                 ?.findInRange(FIND_MY_CONSTRUCTION_SITES, 1)
                 .filter((s) => s.structureType === STRUCTURE_LINK).length >=
-        1;
+            1;
     let observer = roomStructures.filter((structure) => structure.structureType === STRUCTURE_OBSERVER).length;
     let pSpawn = roomStructures.filter((structure) => structure.structureType === STRUCTURE_POWER_SPAWN).length;
 

--- a/src/modules/roomDesign.ts
+++ b/src/modules/roomDesign.ts
@@ -395,16 +395,7 @@ export function roomNeedsCoreStructures(room: Room) {
     let factory = roomStructures.filter((structure) => structure.structureType === STRUCTURE_FACTORY).length;
     let labCount = roomStructures.filter((structure) => structure.structureType === STRUCTURE_LAB).length;
     let towerCount = roomStructures.filter((structure) => structure.structureType === STRUCTURE_TOWER).length;
-    let managerLink =
-        room.memory.anchorPoint?.toRoomPos() ||
-        room.memory.managerPos
-            ?.toRoomPos()
-            ?.findInRange(FIND_MY_STRUCTURES, 1)
-            .filter((s) => s.structureType === STRUCTURE_LINK).length +
-            (room.memory.anchorPoint?.toRoomPos() || room.memory.managerPos?.toRoomPos())
-                ?.findInRange(FIND_MY_CONSTRUCTION_SITES, 1)
-                .filter((s) => s.structureType === STRUCTURE_LINK).length >=
-            1;
+    let managerLink = room.memory.managerLink;
     let observer = roomStructures.filter((structure) => structure.structureType === STRUCTURE_OBSERVER).length;
     let pSpawn = roomStructures.filter((structure) => structure.structureType === STRUCTURE_POWER_SPAWN).length;
 

--- a/src/modules/roomDesign.ts
+++ b/src/modules/roomDesign.ts
@@ -191,6 +191,19 @@ export function getSpawnPos(room: Room) {
     }
 }
 
+export function getBunkerPositions(room: Room): RoomPosition[]{
+    if(room.memory.anchorPoint){
+        let anchor = room.memory.anchorPoint.toRoomPos();
+        let posArr = [];
+        for(let i = -6; i < 7; i++){
+            for (let j = -6; j < 7; j++){
+                posArr.push(room.getPositionAt(anchor.x + i, anchor.y + j));
+            }
+        }
+        return posArr;
+    }
+}
+
 export function getStoragePos(room: Room) {
     switch (room.memory.layout) {
         case RoomLayout.BUNKER:
@@ -1066,7 +1079,7 @@ function containsNonRoadStamp(stamps: Stamps, targetPositions: RoomPosition[]): 
     );
 }
 
-function drawLayout(roomVisual: RoomVisual, stamps: Stamps) {
+export function drawLayout(roomVisual: RoomVisual, stamps: Stamps) {
     Object.entries(stamps)
         .filter(([type, stampDetails]: [string, StampDetail[]]) => type !== STRUCTURE_ROAD)
         .forEach(([type, stampDetails]: [string, StampDetail[]]) => {
@@ -1126,7 +1139,7 @@ function drawLayout(roomVisual: RoomVisual, stamps: Stamps) {
     for (let i = 0; i < roadPositions.length; i++) {
         for (let j = i + 1; j < roadPositions.length; j++) {
             if (roadPositions[i].isNearTo(roadPositions[j])) {
-                roomVisual.line(roadPositions[i], roadPositions[j], { width: 0.3, opacity: 0.8, lineStyle: 'solid' });
+                roomVisual.line(roadPositions[i], roadPositions[j], { width: 0.3, opacity: 0.1, lineStyle: 'solid' });
             }
         }
     }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -264,28 +264,30 @@ export function driveRoom(room: Room) {
             runGates(room);
         }
 
-        //if this room doesn't have any outstanding claims
-        if (
-            Game.time % 1000 !== 0 &&
-            !room.memory.outstandingClaim &&
-            canSupportRemoteRoom(room) &&
-            Game.time % 25 === 0 &&
-            !global.remoteSourcesChecked &&
-            Game.time - (room.memory.lastRemoteSourceCheck ?? 0) > 1000
-        ) {
-            console.log('checking remote sources for ' + room.name);
-            let result = addRemoteSourceClaim(room);
-            room.memory.lastRemoteSourceCheck = Game.time;
-            global.remoteSourcesChecked = true;
-        }
+        if (room.energyStatus >= EnergyStatus.RECOVERING) {
+            //if this room doesn't have any outstanding claims
+            if (
+                Game.time % 1000 !== 0 &&
+                !room.memory.outstandingClaim &&
+                canSupportRemoteRoom(room) &&
+                Game.time % 25 === 0 &&
+                !global.remoteSourcesChecked &&
+                Game.time - (room.memory.lastRemoteSourceCheck ?? 0) > 1000
+            ) {
+                console.log('checking remote sources for ' + room.name);
+                let result = addRemoteSourceClaim(room);
+                room.memory.lastRemoteSourceCheck = Game.time;
+                global.remoteSourcesChecked = true;
+            }
 
-        if (room.memory.outstandingClaim && Game.time % 1000 === 0) {
-            let result = executeRemoteSourceClaim(room);
-            if (result === OK) {
-                delete Memory.remoteSourceClaims[room.memory.outstandingClaim];
-                delete room.memory.outstandingClaim;
-            } else {
-                console.log(`Problem adding ${room.memory.outstandingClaim} as remote source assignment for ${room.name}`);
+            if (room.memory.outstandingClaim && Game.time % 1000 === 0) {
+                let result = executeRemoteSourceClaim(room);
+                if (result === OK) {
+                    delete Memory.remoteSourceClaims[room.memory.outstandingClaim];
+                    delete room.memory.outstandingClaim;
+                } else {
+                    console.log(`Problem adding ${room.memory.outstandingClaim} as remote source assignment for ${room.name}`);
+                }
             }
         }
 

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -853,7 +853,7 @@ function getStructurePriority(structureType: StructureConstant): number {
 }
 
 export function canSupportRemoteRoom(room: Room) {
-    return room.remoteSources.length < 2;
+    return true;
 }
 
 function initMissingMemoryValues(room: Room) {

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -1,6 +1,6 @@
 import { CombatIntel } from './combatIntel';
 import { runLabs } from './labManagement';
-import { getExitDirections, isCenterRoom, isKeeperRoom, posFromMem } from './data';
+import { getExitDirections, isCenterRoom, isKeeperRoom } from './data';
 import { PopulationManagement } from './populationManagement';
 import { addRemoteRoom, manageRemoteRoom } from './remoteRoomManagement';
 import {
@@ -219,7 +219,7 @@ export function driveRoom(room: Room) {
         runTowers(room, isHomeUnderAttack);
 
         if (room.memory.anchorPoint) {
-            let anchorPoint = posFromMem(room.memory.anchorPoint);
+            let anchorPoint = room.memory.anchorPoint.toRoomPos();
             if (
                 anchorPoint
                     .findInRange(FIND_HOSTILE_CREEPS, 6)
@@ -522,7 +522,7 @@ function findMiningPostitions(room: Room) {
             .map((terrain) => new RoomPosition(terrain.x, terrain.y, source.room.name));
 
         //set closest position to storage as container position
-        let anchorPoint = posFromMem(room.memory.anchorPoint);
+        let anchorPoint = room.memory.anchorPoint.toRoomPos();
         let referencePos = anchorPoint ? new RoomPosition(anchorPoint.x + 1, anchorPoint.y - 1, room.name) : room.controller.pos;
         let candidate = referencePos.findClosestByPath(possiblePositions, { ignoreCreeps: true });
         if (candidate) {
@@ -545,7 +545,7 @@ function findMineralMiningPosition(room: Room): RoomPosition {
         .map((terrain) => new RoomPosition(terrain.x, terrain.y, room.mineral.room.name));
 
     //set closest position to storage as container position
-    let anchorPoint = posFromMem(room.memory.anchorPoint);
+    let anchorPoint = room.memory.anchorPoint.toRoomPos();
     let referencePos = anchorPoint ? new RoomPosition(anchorPoint.x + 1, anchorPoint.y - 1, room.name) : room.controller.pos;
     let candidate = referencePos.findClosestByPath(possiblePositions, { ignoreCreeps: true });
     if (candidate) {
@@ -625,7 +625,7 @@ function runSpawning(room: Room) {
 
     if (PopulationManagement.needsManager(room)) {
         if (room.memory.layout === RoomLayout.BUNKER) {
-            const suitableSpawn = availableSpawns.find((spawn) => spawn.pos.isNearTo(posFromMem(room.memory.anchorPoint)));
+            const suitableSpawn = availableSpawns.find((spawn) => spawn.pos.isNearTo(room.memory.anchorPoint.toRoomPos()));
             if (suitableSpawn) {
                 suitableSpawn.spawnManager();
                 availableSpawns = availableSpawns.filter((spawn) => spawn !== suitableSpawn);
@@ -742,14 +742,14 @@ function runGates(room: Room): void {
 }
 
 function placeMiningPositionContainers(room: Room) {
-    let miningPositions = Object.keys(room.memory.miningAssignments).map((pos) => posFromMem(pos));
+    let miningPositions = Object.keys(room.memory.miningAssignments).map((pos) => pos.toRoomPos());
     miningPositions.forEach((pos) => {
         room.createConstructionSite(pos.x, pos.y, STRUCTURE_CONTAINER);
     });
 }
 
 function placeMiningRamparts(room: Room) {
-    let miningPositions = Object.keys(room.memory.miningAssignments).map((pos) => posFromMem(pos));
+    let miningPositions = Object.keys(room.memory.miningAssignments).map((pos) => pos.toRoomPos());
     miningPositions.forEach((pos) => {
         room.createConstructionSite(pos.x, pos.y, STRUCTURE_RAMPART);
     });
@@ -762,7 +762,7 @@ function placeMineralContainers(room: Room) {
         room.memory.mineralMiningAssignments[mineralMiningPos.toMemSafe()] = AssignmentStatus.UNASSIGNED;
     }
 
-    let miningPositions = Object.keys(room.memory.mineralMiningAssignments).map((pos) => posFromMem(pos));
+    let miningPositions = Object.keys(room.memory.mineralMiningAssignments).map((pos) => pos.toRoomPos());
     miningPositions.forEach((pos) => {
         Game.rooms[pos.roomName]?.createConstructionSite(pos.x, pos.y, STRUCTURE_CONTAINER);
     });
@@ -954,7 +954,7 @@ export function findRemoteMiningOptions(room: Room): { source: string; stats: Re
         .filter((source) => !Memory.remoteSourceAssignments[source])
         .map((source) => {
             console.log(source);
-            let sourcePos = posFromMem(source);
+            let sourcePos = source.toRoomPos();
             let stats = calculateRemoteSourceStats(sourcePos, room);
             return { source, stats };
         });

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -899,7 +899,7 @@ function initMissingMemoryValues(room: Room) {
 }
 
 export function addRemoteSourceClaim(room: Room) {
-    let sourceToClaim = findSuitableRemoteSource(room.name, true);
+    let sourceToClaim = findSuitableRemoteSource(room.name);
 
     //if a room to claim is found, claim it if available and no closer claimant
     if (sourceToClaim) {

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -853,7 +853,7 @@ function getStructurePriority(structureType: StructureConstant): number {
 }
 
 export function canSupportRemoteRoom(room: Room) {
-    return false; //Object.keys(room.memory.remoteSources).length < room.find(FIND_MY_SPAWNS).length * 3;
+    return Object.keys(room.memory.remoteSources).length < room.find(FIND_MY_SPAWNS).length * 3;
 }
 
 function initMissingMemoryValues(room: Room) {
@@ -905,13 +905,13 @@ export function addRemoteSourceClaim(room: Room) {
     if (sourceToClaim) {
         let existingClaim = Memory.remoteSourceClaims[sourceToClaim.source];
         if (existingClaim) {
-            if (existingClaim.netIncome < sourceToClaim.stats.estimatedIncome) {
-                Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, netIncome: sourceToClaim.stats.estimatedIncome };
+            if (existingClaim.estimatedIncome < sourceToClaim.stats.estimatedIncome) {
+                Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, estimatedIncome: sourceToClaim.stats.estimatedIncome };
                 room.memory.outstandingClaim = sourceToClaim.source;
                 delete Memory.rooms[existingClaim.claimant].outstandingClaim;
             }
         } else {
-            Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, netIncome: sourceToClaim.stats.estimatedIncome };
+            Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, estimatedIncome: sourceToClaim.stats.estimatedIncome };
             room.memory.outstandingClaim = sourceToClaim.source;
         }
     }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -88,6 +88,7 @@ export function driveRoom(room: Room) {
                 Object.keys(Game.constructionSites).length < MAX_CONSTRUCTION_SITES &&
                 room.find(FIND_MY_CONSTRUCTION_SITES).length < 15
             ) {
+                let cpuUsed = Game.cpu.getUsed();
                 switch (room.controller.level) {
                     case 8:
                         if (!roomNeedsCoreStructures(room)) {
@@ -118,6 +119,10 @@ export function driveRoom(room: Room) {
                 }
                 global.roomConstructionsChecked = true;
                 room.memory.dontCheckConstructionsBefore = Game.time + BUILD_CHECK_PERIOD;
+                cpuUsed = Game.cpu.getUsed() - cpuUsed;
+                if (Memory.debug.logRoomPlacementCpu) {
+                    console.log(`CPU used on ${room.name} bunker layout: ${cpuUsed}`);
+                }
             }
 
             if (
@@ -128,6 +133,7 @@ export function driveRoom(room: Room) {
                 Object.keys(Game.constructionSites).length < MAX_CONSTRUCTION_SITES &&
                 room.find(FIND_MY_CONSTRUCTION_SITES).length < 15
             ) {
+                let cpuUsed = 0;
                 // Cleanup any leftover storage/terminal that is in the way
                 if (
                     room.stamps.spawn.some(
@@ -212,6 +218,10 @@ export function driveRoom(room: Room) {
 
                 global.roomConstructionsChecked = true;
                 room.memory.dontCheckConstructionsBefore = Game.time + BUILD_CHECK_PERIOD;
+                cpuUsed = Game.cpu.getUsed() - cpuUsed;
+                if (Memory.debug.logRoomPlacementCpu) {
+                    console.log(`CPU used on ${room.name} stamp layout: ${cpuUsed}`);
+                }
             }
         }
 
@@ -255,7 +265,6 @@ export function driveRoom(room: Room) {
 
         //if this room doesn't have any outstanding claims
         if (canSupportRemoteRoom(room) && !room.memory.outstandingClaim && Game.time % 25 === 0) {
-            
         }
 
         // if (room.memory.outstandingClaim && Game.time % 300 === 0) {
@@ -873,12 +882,12 @@ function initMissingMemoryValues(room: Room) {
         room.memory.visionRequests = [];
     }
 
-    if(!room.memory.remoteSources) {
+    if (!room.memory.remoteSources) {
         room.memory.remoteSources = {};
     }
 }
 
-export function addRemoteSourceClaim(room: Room){
+export function addRemoteSourceClaim(room: Room) {
     let sourceToClaim = findSuitableRemoteSource(room, true);
 
     //if a room to claim is found, claim it if available and no closer claimant
@@ -899,7 +908,7 @@ export function addRemoteSourceClaim(room: Room){
     return sourceToClaim;
 }
 
-export function executeRemoteSourceClaim(room: Room){
+export function executeRemoteSourceClaim(room: Room) {
     let result = assignRemoteSource(room.memory.outstandingClaim, room.name);
     if (result === OK) {
         delete Memory.remoteSourceClaims[room.memory.outstandingClaim];

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -853,7 +853,7 @@ function getStructurePriority(structureType: StructureConstant): number {
 }
 
 export function canSupportRemoteRoom(room: Room) {
-    return Object.keys(room.memory.remoteSources).length < room.find(FIND_MY_SPAWNS).length * 3;
+    return false; //Object.keys(room.memory.remoteSources).length < room.find(FIND_MY_SPAWNS).length * 3;
 }
 
 function initMissingMemoryValues(room: Room) {
@@ -899,19 +899,19 @@ function initMissingMemoryValues(room: Room) {
 }
 
 export function addRemoteSourceClaim(room: Room) {
-    let sourceToClaim = findSuitableRemoteSource(room, true);
+    let sourceToClaim = findSuitableRemoteSource(room.name, true);
 
     //if a room to claim is found, claim it if available and no closer claimant
     if (sourceToClaim) {
         let existingClaim = Memory.remoteSourceClaims[sourceToClaim.source];
         if (existingClaim) {
-            if (existingClaim.netIncome < sourceToClaim.stats.netIncome) {
-                Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, netIncome: sourceToClaim.stats.netIncome };
+            if (existingClaim.netIncome < sourceToClaim.stats.estimatedIncome) {
+                Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, netIncome: sourceToClaim.stats.estimatedIncome };
                 room.memory.outstandingClaim = sourceToClaim.source;
                 delete Memory.rooms[existingClaim.claimant].outstandingClaim;
             }
         } else {
-            Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, netIncome: sourceToClaim.stats.netIncome };
+            Memory.remoteSourceClaims[sourceToClaim.source] = { claimant: room.name, netIncome: sourceToClaim.stats.estimatedIncome };
             room.memory.outstandingClaim = sourceToClaim.source;
         }
     }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -231,17 +231,17 @@ export function driveRoom(room: Room) {
                 room.controller.activateSafeMode();
             }
         } else if (room.memory.layout === RoomLayout.STAMP) {
-            const centerLink = room.memory.stampLayout.link.find((linkDetail) => linkDetail.type === 'center');
             if (
-                centerLink &&
                 room
                     .find(FIND_HOSTILE_CREEPS)
                     .some(
                         (creep) =>
                             creep.owner.username !== 'Invader' &&
                             (creep.getActiveBodyparts(WORK) || creep.getActiveBodyparts(ATTACK) || creep.getActiveBodyparts(RANGED_ATTACK)) &&
-                            (creep.pos.x > 2 || creep.pos.y > 2) &&
-                            (creep.pos.x < 47 || creep.pos.y < 47)
+                            creep.pos.x > 2 &&
+                            creep.pos.y > 2 &&
+                            creep.pos.x < 47 &&
+                            creep.pos.y < 47
                     )
             ) {
                 room.controller.activateSafeMode();

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -271,7 +271,6 @@ export function driveRoom(room: Room) {
                 !global.remoteSourcesChecked &&
                 Game.time - (room.memory.lastRemoteSourceCheck ?? 0) > 1000
             ) {
-                console.log('checking remote sources for ' + room.name);
                 let result = addRemoteSourceClaim(room);
                 room.memory.lastRemoteSourceCheck = Game.time;
                 global.remoteSourcesChecked = true;

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -853,7 +853,7 @@ function getStructurePriority(structureType: StructureConstant): number {
 }
 
 export function canSupportRemoteRoom(room: Room) {
-    return true;
+    return Object.keys(room.memory.remoteSources).length < room.find(FIND_MY_SPAWNS).length * 3;
 }
 
 function initMissingMemoryValues(room: Room) {

--- a/src/modules/squadManagement.ts
+++ b/src/modules/squadManagement.ts
@@ -1,5 +1,4 @@
 import { CombatCreep } from '../virtualCreeps/combatCreep';
-import { posFromMem } from './data';
 import { Pathing } from './pathing';
 
 export class SquadManagement {
@@ -332,7 +331,7 @@ export class SquadManagement {
                     Memory.squads[this.squadId].forcedDestinations = this.forcedDestinations.slice(1);
                     nextDestination = this.forcedDestinations[0];
                 }
-                this.squadLeader.travelTo(posFromMem(nextDestination));
+                this.squadLeader.travelTo(nextDestination.toRoomPos());
             } else if (Game.flags.squadMove?.pos?.roomName === this.assignment) {
                 // Manual Pathing
                 this.squadLeader.travelTo(Game.flags.squadMove);
@@ -451,7 +450,7 @@ export class SquadManagement {
             // Manual targeting (costMatrix disabled?)
             return Pathing.findTravelPath(this.squadLeader, this.squadLeader.pos, Game.flags.squadMove.pos, { customMatrixCosts: matrix });
         }
-        if (posFromMem(this.squadLeader.memory._m.lastCoord).roomName !== this.squadLeader.pos.roomName) {
+        if (this.squadLeader.memory._m.lastCoord.toRoomPos().roomName !== this.squadLeader.pos.roomName) {
             delete this.squadLeader.memory._m.path;
         }
         if (target && !this.squadLeader.memory._m.path) {
@@ -812,9 +811,9 @@ export class SquadManagement {
                     Memory.squads[this.squadId].forcedDestinations = this.forcedDestinations.slice(1);
                     nextDestination = this.forcedDestinations[0];
                 }
-                this.squadLeader.travelTo(posFromMem(nextDestination));
+                this.squadLeader.travelTo(nextDestination.toRoomPos());
             } else if (this.squadLeader.pos.roomName === this.assignment) {
-                this.squadLeader.travelTo(posFromMem(this.squadLeader.memory._m.destination));
+                this.squadLeader.travelTo(this.squadLeader.memory._m.destination.toRoomPos());
             } else {
                 const exits = Game.map.describeExits(this.squadLeader.room.name);
                 if (Object.values(exits).find((exit) => exit === this.assignment)) {

--- a/src/modules/visuals.ts
+++ b/src/modules/visuals.ts
@@ -1,17 +1,17 @@
-import { decodeRoad, getRoadSegments } from "./roads";
-import { drawLayout } from "./roomDesign";
+import { decodeRoad, getRoadSegments } from './roads';
+import { drawLayout } from './roomDesign';
 
 export function runVisuals() {
     highlightHostileRooms();
-    if(Memory.debug?.drawRoads){
+    if (Memory.debug?.drawRoads) {
         drawRoadsFromRoomData();
     }
 
-    if(Memory.debug?.drawRemoteConnections){
+    if (Memory.debug?.drawRemoteConnections) {
         drawLinesToRemoteRooms();
     }
 
-    if(Memory.debug?.drawStamps){
+    if (Memory.debug?.drawStamps) {
         drawRoomVisuals();
     }
 }
@@ -21,12 +21,15 @@ function drawRoadsFromRoomData() {
         let rv = new RoomVisual(room);
         let roads = Memory.roomData[room]?.roads ? Object.values(Memory.roomData[room].roads) : [];
         if (roads?.length) {
-            let rvRoads = [];
+            let roadSegments = [];
             roads.forEach((roadCode) => {
                 let road = decodeRoad(roadCode, room);
-                getRoadSegments(road).forEach(segment => rvRoads.push(segment));
+                getRoadSegments(road).forEach((segment) => roadSegments.push(segment));
             });
-            rvRoads.forEach((roadSegment) => rv.poly(roadSegment, { lineStyle: 'dotted', stroke: '#63FF00', opacity: 100 }));
+            roadSegments.forEach((roadSegment) => {
+                rv.poly(roadSegment, { lineStyle: 'dotted', stroke: '#63FF00', opacity: 100 });
+                Game.map.visual.poly(roadSegment, { lineStyle: 'dotted', stroke: '#63FF00', opacity: 100 });
+            });
         }
     });
 }
@@ -49,11 +52,13 @@ function drawLinesToRemoteRooms() {
         });
 }
 
-function drawRoomVisuals(){
-    Object.keys(Memory.rooms).filter(room => Memory.rooms[room].stampLayout).forEach(stampRoom => {
-        let rv = Game.rooms[stampRoom]?.visual;
-        if(rv){
-            drawLayout(rv, Game.rooms[stampRoom].stamps);
-        }
-    })
+function drawRoomVisuals() {
+    Object.keys(Memory.rooms)
+        .filter((room) => Memory.rooms[room].stampLayout)
+        .forEach((stampRoom) => {
+            let rv = Game.rooms[stampRoom]?.visual;
+            if (rv) {
+                drawLayout(rv, Game.rooms[stampRoom].stamps);
+            }
+        });
 }

--- a/src/modules/visuals.ts
+++ b/src/modules/visuals.ts
@@ -1,0 +1,47 @@
+export function runVisuals() {
+    highlightHostileRooms();
+    drawRoadsFromRoomData();
+    drawLinesToRemoteRooms();
+}
+
+function drawRoadsFromRoomData() {
+    Object.keys(Memory.roomData).forEach((room) => {
+        let rv = new RoomVisual(room);
+        let roads = Memory.roomData[room]?.roads ? Object.values(Memory.roomData[room].roads) : [];
+        if (roads?.length) {
+            let rvRoads = [];
+            roads.forEach((road) => {
+                let arr = [];
+                road.split(',').forEach((posString) => {
+                    let split = posString.split(':').map((v) => parseInt(v));
+
+                    let pos;
+                    try {
+                        pos = new RoomPosition(split[0], split[1], room);
+                        arr.push(pos);
+                    } catch (e) {}
+                });
+                rvRoads.push(arr);
+            });
+            rvRoads.forEach((road) => rv.poly(road, { lineStyle: 'dotted' }));
+        }
+    });
+}
+
+function highlightHostileRooms() {
+    Object.keys(Memory.roomData)
+        .filter((roomName) => Memory.roomData[roomName].hostile)
+        .forEach((roomName) => {
+            Game.map.visual.rect(new RoomPosition(0, 0, roomName), 50, 50, { fill: '#8b0000', stroke: '#8b0000', strokeWidth: 2 });
+        });
+}
+
+function drawLinesToRemoteRooms() {
+    Object.keys(Game.rooms)
+        .filter((room) => Game.rooms[room]?.controller?.my)
+        .forEach((room) => {
+            Memory.rooms[room].remoteMiningRooms.forEach((remoteRoom) => {
+                Game.map.visual.line(new RoomPosition(25, 25, room), new RoomPosition(25, 25, remoteRoom), { color: '3333ff', opacity: 100 });
+            });
+        });
+}

--- a/src/modules/visuals.ts
+++ b/src/modules/visuals.ts
@@ -3,9 +3,17 @@ import { drawLayout } from "./roomDesign";
 
 export function runVisuals() {
     highlightHostileRooms();
-    drawRoadsFromRoomData();
-    drawLinesToRemoteRooms();
-    drawRoomVisuals();
+    if(Memory.debug?.drawRoads){
+        drawRoadsFromRoomData();
+    }
+
+    if(Memory.debug?.drawRemoteConnections){
+        drawLinesToRemoteRooms();
+    }
+
+    if(Memory.debug?.drawStamps){
+        drawRoomVisuals();
+    }
 }
 
 function drawRoadsFromRoomData() {

--- a/src/prototypes/requirePrototypes.ts
+++ b/src/prototypes/requirePrototypes.ts
@@ -4,3 +4,4 @@ require('./structureSpawn');
 require('./structureController');
 require('./structureLab');
 require('./structure');
+require('./string');

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -1,5 +1,4 @@
 import { addLabTask, getResourceBoostsAvailable } from '../modules/labManagement';
-import { posFromMem } from '../modules/data';
 import { PopulationManagement } from '../modules/populationManagement';
 import { getFactoryResourcesNeeded } from '../modules/resourceManagement';
 import { findRepairTargets, getStructuresToProtect } from '../modules/roomManagement';
@@ -95,7 +94,7 @@ Object.defineProperty(Room.prototype, 'mineral', {
 
 Object.defineProperty(Room.prototype, 'managerLink', {
     get: function (this: Room) {
-        let posToCheck = posFromMem(this.memory.anchorPoint || this.memory.managerPos);
+        let posToCheck = this.memory.anchorPoint?.toRoomPos() || this.memory.managerPos?.toRoomPos();
         if (this.memory.layout === RoomLayout.STAMP) {
             posToCheck = this.stamps.link.find((linkDetail) => linkDetail.type === 'rm')?.pos;
         } else if (this.memory.managerLink) {
@@ -119,7 +118,7 @@ Object.defineProperty(Room.prototype, 'upgraderLink', {
         if (this.memory.layout === RoomLayout.STAMP) {
             posToCheck = this.stamps.link.find((linkDetail) => linkDetail.type === 'controller')?.pos;
         } else {
-            posToCheck = posFromMem(this.memory.upgraderLinkPos);
+            posToCheck = this.memory.upgraderLinkPos.toRoomPos();
         }
 
         let link = posToCheck

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -181,6 +181,22 @@ Object.defineProperty(Room.prototype, 'stamps', {
     configurable: true,
 });
 
+Object.defineProperty(Room.prototype, 'remoteSources', {
+    get: function (this: Room) {
+        return Object.keys(this.memory.remoteSources);
+    },
+    enumerable: false,
+    configurable: true,
+});
+
+Object.defineProperty(Room.prototype, 'remoteMiningRooms', {
+    get: function (this: Room) {
+        return this.remoteSources.map(s => s.split('.')[2]);
+    },
+    enumerable: false,
+    configurable: true,
+});
+
 Room.prototype.addLabTask = function (this: Room, opts: LabTaskOpts): ScreepsReturnCode {
     return addLabTask(this, opts);
 };

--- a/src/prototypes/string.ts
+++ b/src/prototypes/string.ts
@@ -3,6 +3,9 @@ interface String {
 }
 
 String.prototype.toRoomPos = function(this: string) {
+
+    if(!this) return undefined;
+
     try{
         let split = this.split('.');
         return new RoomPosition(parseInt(split[0]), parseInt(split[1]), split[2]);

--- a/src/prototypes/string.ts
+++ b/src/prototypes/string.ts
@@ -1,0 +1,13 @@
+interface String {
+    toRoomPos(): RoomPosition
+}
+
+String.prototype.toRoomPos = function(this: string) {
+    try{
+        let split = this.split('.');
+        return new RoomPosition(parseInt(split[0]), parseInt(split[1]), split[2]);
+    } catch (e) {
+        console.log(`error parsing room position from string: ${this}`);
+        return undefined;
+    }
+}

--- a/src/prototypes/structureSpawn.ts
+++ b/src/prototypes/structureSpawn.ts
@@ -8,12 +8,12 @@ StructureSpawn.prototype.spawnDistributor = function () {
     return PopulationManagement.spawnDistributor(this);
 };
 
-StructureSpawn.prototype.spawnRemoteMiner = function (remoteRoomName: string) {
-    return PopulationManagement.spawnRemoteMiner(this, remoteRoomName);
+StructureSpawn.prototype.spawnRemoteMiner = function (source: string) {
+    return PopulationManagement.spawnRemoteMiner(this, source);
 };
 
-StructureSpawn.prototype.spawnGatherer = function (remoteRoomName: string) {
-    return PopulationManagement.spawnGatherer(this, remoteRoomName);
+StructureSpawn.prototype.spawnGatherer = function (source: string) {
+    return PopulationManagement.spawnGatherer(this, source);
 };
 
 StructureSpawn.prototype.spawnReserver = function (remoteRoomName: string) {

--- a/src/roles/claimer.ts
+++ b/src/roles/claimer.ts
@@ -1,4 +1,3 @@
-import { posFromMem } from '../modules/data';
 import { PopulationManagement } from '../modules/populationManagement';
 import { posInsideBunker } from '../modules/roomDesign';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
@@ -10,7 +9,7 @@ export class Claimer extends WaveCreep {
                 this.memory.assignment = this.room.controller.pos.toMemSafe();
             }
         } else {
-            let targetPos = posFromMem(this.memory.assignment);
+            let targetPos = this.memory.assignment.toRoomPos();
 
             if (this.room.name === this.memory.destination) {
                 // If there is an invader claimer in the room send a cleanup creep

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -32,6 +32,7 @@ export class Gatherer extends TransportCreep {
                 this.storeCargo();
             }
         } else {
+            this.memory.currentTaskPriority = Priority.MEDIUM;
             if (this.pos.isNearTo(this.memory.assignment.toRoomPos())) {
                 let container = Game.getObjectById(this.getContainerId()) as StructureContainer;
                 if (container) {

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -57,6 +57,10 @@ export class Gatherer extends TransportCreep {
                 this.travelTo(this.homeroom.storage, opts);
                 break;
             case 0:
+                let source = Object.keys(this.homeroom.memory.remoteSources).find(
+                    (s) => this.homeroom.memory.remoteSources[s].miningPos === this.memory.assignment
+                );
+                delete Memory.rooms[this.memory.room].remoteSources[source].setupStatus;
                 break;
         }
     }

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -1,5 +1,6 @@
 import { isKeeperRoom } from '../modules/data';
 import { Pathing } from '../modules/pathing';
+import { posExistsOnRoad } from '../modules/roads';
 import { TransportCreep } from '../virtualCreeps/transportCreep';
 
 export class Gatherer extends TransportCreep {
@@ -10,241 +11,55 @@ export class Gatherer extends TransportCreep {
             return;
         }
 
-        let target: any = Game.getObjectById(this.memory.targetId);
-        if (!target) {
-            if (Game.rooms[this.memory.assignment] || this.travelToRoom(this.memory.assignment) === IN_ROOM) {
-                // Find target is visibility exists
-                this.memory.targetId = this.findTarget();
-                target = Game.getObjectById(this.memory.targetId);
-            }
-        }
-
-        if (target instanceof Resource) {
-            this.runPickupJob(target);
-        } else if (target instanceof Tombstone || target instanceof StructureContainer) {
-            this.runCollectionJob(target);
-            // Only store Roads starting from containers
-            if (target instanceof StructureContainer) {
-                this.memory.storeRoadInMemory = target.id;
-            }
-        } else if (target instanceof StructureStorage) {
-            if (this.store.energy) {
-                if (this.getActiveBodyparts(WORK) && !this.roadIsServicable() && this.isOnPath()) {
-                    this.workOnRoad();
+        if(this.store.getUsedCapacity()){
+            if(!this.onEdge() && posExistsOnRoad(this.pos)){
+                let road = this.pos.lookFor(LOOK_STRUCTURES).find(s => s.structureType === STRUCTURE_ROAD) as StructureRoad;
+                if(road){
+                    this.repairRoad(road);
+                    this.storeCargo();
                 } else {
-                    this.storeAndRepair();
-                }
-            } else {
-                delete this.memory.targetId;
-            }
-        } else {
-            delete this.memory.targetId;
-        }
-
-        // Cleanup road memory once back in homeroom
-        if (this.pos.roomName === this.memory.room) {
-            delete this.memory.storeRoadInMemory; // only needed to initially store road in memory
-        }
-    }
-
-    private storeAndRepair(): void {
-        let roomPositions = [];
-        // only get roomPositions if storeRoadInMemory is set AND there isnt already a road in memory for that room or the homeroom. The homeroom is checked to avoid adding more roads when rerouting due to hostiles
-        roomPositions = this.storeCargo(
-            this.memory.storeRoadInMemory &&
-                (!Memory.roomData[this.pos.roomName].roads || !Memory.roomData[this.pos.roomName].roads[this.memory.storeRoadInMemory]) &&
-                (this.onEdge() || this.pos.isNearTo(Game.getObjectById(this.memory.storeRoadInMemory)))
-        );
-        // Going back to storage
-        if (this.memory._m.destination?.toRoomPos()?.roomName === this.memory.room) {
-            this.storeRoadInMemory(roomPositions);
-        }
-
-        this.repairRoad();
-    }
-
-    protected storeRoadInMemory(roomPositions: RoomPosition[]) {
-        roomPositions
-            ?.filter((pos) => pos.x < 49 && pos.y < 49 && pos.x > 0 && pos.y > 0 && this.pos.roomName === pos.roomName) // only store in memory for current room
-            .forEach((pos) => {
-                if (!Memory.roomData[pos.roomName].roads) {
-                    Memory.roomData[pos.roomName].roads = {};
-                }
-                let delimiter = ',';
-                // Initialize new road path
-                if (!Memory.roomData[pos.roomName].roads[this.memory.storeRoadInMemory]) {
-                    // only for first pos from container instead of when entering new room
-                    if (!this.onEdge()) {
-                        Memory.roomData[pos.roomName].roads[this.memory.storeRoadInMemory] = `${this.pos.x}:${this.pos.y}`;
+                    let site = this.pos.lookFor(LOOK_CONSTRUCTION_SITES).find(site => site.my && site.structureType === STRUCTURE_ROAD);
+                    if(site){
+                        this.build(site);
                     } else {
-                        delimiter = '';
-                        Memory.roomData[pos.roomName].roads[this.memory.storeRoadInMemory] = '';
+                        this.pos.createConstructionSite(STRUCTURE_ROAD);
                     }
                 }
-                Memory.roomData[pos.roomName].roads[this.memory.storeRoadInMemory] += `${delimiter}${pos.x}:${pos.y}`;
-            });
-    }
-
-    protected isOnPath() {
-        if (this.onEdge() || !Memory.roomData[this.pos.roomName].roads) {
-            return false;
+            } else{
+                this.storeCargo();
+            }
+        } else {
+            if(this.pos.isNearTo(this.memory.assignment.toRoomPos())){
+                let container = Game.getObjectById(this.getContainerId()) as StructureContainer;
+                if(container){
+                    this.withdraw(container, Object.keys(container.store).shift() as ResourceConstant);
+                    let road = this.pos.lookFor(LOOK_STRUCTURES).find(s => s.structureType === STRUCTURE_ROAD) as StructureRoad;
+                    this.repairRoad(road);
+                    this.storeCargo();
+                }
+            } else {
+                this.travelTo(this.memory.assignment.toRoomPos(), {range: 1});
+            }
         }
-        return Object.values(Memory.roomData[this.pos.roomName].roads).some((path) =>
-            path.split(',').some((pos) => pos === `${this.pos.x}:${this.pos.y}`)
-        );
     }
 
-    protected findTarget() {
-        // Gather
-        if (this.store.getUsedCapacity() < this.store.getCapacity() * 0.8) {
-            return this.findCollectionTarget(this.memory.assignment);
-        }
-
-        // Hauler
-        return this.homeroom.storage?.id;
-    }
-
-    protected storeCargo(retrievePathPositions?: boolean) {
+    protected storeCargo() {
         this.memory.currentTaskPriority = Priority.MEDIUM;
         let resourceToStore: any = Object.keys(this.store).shift();
         let storeResult = this.transfer(this.homeroom.storage, resourceToStore);
         let opts = { ignoreCreeps: true, range: 1, preferRoadConstruction: true } as TravelToOpts;
-        if (retrievePathPositions) {
-            opts.pathsRoomPositions = [];
-            opts.reusePath = 0; // force reevaluation of the path
-        }
         switch (storeResult) {
             case ERR_NOT_IN_RANGE:
                 this.travelTo(this.homeroom.storage, opts);
                 break;
             case 0:
-                if (this.store[resourceToStore] === this.store.getUsedCapacity()) {
-                    this.onTaskFinished();
-                }
-                break;
-            default:
-                this.onTaskFinished();
                 break;
         }
-        if (!opts.pathsRoomPositions || opts.avoidedTemporaryHostileRooms || this.memory._m.repath) {
-            if (opts.avoidedTemporaryHostileRooms || this.memory._m.repath) {
-                delete this.memory.storeRoadInMemory; // Do not store Roads when path went around temporary hostile room
-            }
-            return [];
-        }
-        return opts.pathsRoomPositions;
     }
-
-    /**
-     * Repair road on current creep position if necessary
-     */
-    private workOnRoad() {
-        const site = this.pos
-            .look()
-            .find(
-                (object) =>
-                    (object.type === LOOK_STRUCTURES &&
-                        object.structure.structureType === STRUCTURE_ROAD &&
-                        object.structure.hits < object.structure.hitsMax) ||
-                    (object.type === LOOK_CONSTRUCTION_SITES && object.constructionSite.structureType === STRUCTURE_ROAD)
-            );
-        if (site) {
-            if (site.type === LOOK_CONSTRUCTION_SITES) {
-                this.build(site.constructionSite);
-            } else if (site.type === LOOK_STRUCTURES) {
-                this.repair(site.structure);
-            }
-        } else {
-            this.room.createConstructionSite(this.pos, STRUCTURE_ROAD);
-        }
-    }
-
-    private roadIsServicable(): boolean {
-        const road = this.pos.lookFor(LOOK_STRUCTURES).find((structure) => structure.structureType === STRUCTURE_ROAD);
-        if (road && road.hits > road.hitsMax * 0.75) {
-            return true;
-        }
-        return false;
-    }
-
-    protected findCollectionTarget(roomName?: string): Id<Resource> | Id<Structure> | Id<Tombstone> {
-        const miningPositions = Memory.remoteData[roomName].miningPositions;
-
-        const targets: { id: Id<Resource> | Id<Structure> | Id<Tombstone>; amount: number }[] = [];
-
-        Object.values(miningPositions).forEach((posString) => {
-            const pos = posString.toRoomPos();
-            const areaInRange = Pathing.getArea(pos, 3);
-            const lookArea = Game.rooms[roomName].lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true);
-            if (
-                isKeeperRoom(pos.roomName) &&
-                (lookArea.some((look) => look.creep?.owner?.username === 'Source Keeper') || this.destinationSpawningKeeper(posString))
-            ) {
-                return;
-            }
-            lookArea
-                .filter((look) => look.resource?.resourceType === RESOURCE_ENERGY || look.tombstone?.store.energy)
-                .forEach((look) => {
-                    if (look.resource) {
-                        targets.push({ id: look.resource.id, amount: look.resource.amount });
-                    } else {
-                        targets.push({ id: look.tombstone.id, amount: look.tombstone.store?.energy });
-                    }
-                });
-
-            const container: StructureContainer = pos
-                .lookFor(LOOK_STRUCTURES)
-                .find((s) => s.structureType === STRUCTURE_CONTAINER) as StructureContainer;
-            if (container && container.store.getUsedCapacity()) {
-                targets.push({ id: container.id, amount: container.store.getUsedCapacity() });
-            }
-        });
-
-        // Ensure that if there are 2 gatherers they do not go toward same target
-        const isMainGatherer = this.name === Memory.remoteData[roomName].gatherer;
-        const secondGatherer = isMainGatherer ? Memory.remoteData[roomName].gathererSK : Memory.remoteData[roomName].gatherer;
-        let excludeTargetId: string;
-        if (secondGatherer && secondGatherer !== AssignmentStatus.UNASSIGNED) {
-            excludeTargetId = Game.creeps[secondGatherer]?.memory?.targetId;
-            // Main gatherer always has first dibs on targets (this prevents same target allocation when both gatherers look for a target at the same time)
-            if (!isMainGatherer && Game.creeps[secondGatherer]?.ticksToLive && !excludeTargetId) {
-                return undefined;
-            }
-        }
-
-        // If there are no more targets check for any loose resources (creeps that died on the way or at mineral)
-        if (!targets.length) {
-            const resources = Game.rooms[roomName].find(FIND_DROPPED_RESOURCES);
-            resources.forEach((resource) => targets.push({ id: resource.id, amount: resource.amount }));
-        }
-
-        // Get highest target unless a target is close by then pick that up first
-        let selectedTarget: { id: Id<Resource> | Id<Structure> | Id<Tombstone>; amount: number } = {
-            id: undefined,
-            amount: 0,
-        };
-        targets
-            .filter((target) => target.id !== excludeTargetId)
-            .every((target) => {
-                if (this.pos.roomName === this.memory.assignment && this.pos.getRangeTo(Game.getObjectById(target.id)) <= 3) {
-                    selectedTarget = target;
-                    return false;
-                }
-                if (selectedTarget.amount < target.amount) {
-                    selectedTarget = target;
-                }
-                return true;
-            });
-
-        return selectedTarget?.id;
-    }
-
-    private repairRoad(): void {
-        if (this.isOnPath() && this.getActiveBodyparts(WORK)) {
-            const road = this.pos.lookFor(LOOK_STRUCTURES).find((structure) => structure.structureType === STRUCTURE_ROAD);
-            if (road?.hits < road?.hitsMax) {
-                this.repair(road);
-            }
+    
+    private repairRoad(road: StructureRoad): void {
+        if (road?.hits < road?.hitsMax) {
+            this.repair(road);
         }
     }
 
@@ -252,15 +67,29 @@ export class Gatherer extends TransportCreep {
         return this.hits < this.hitsMax * 0.85;
     }
 
-    private destinationSpawningKeeper(pos: string): boolean {
-        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceIdByMiningPos(pos)];
+    private destinationSpawningKeeper(): boolean {
+        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceId()];
         const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
         return lairInRange?.ticksToSpawn < 20;
     }
 
-    private getSourceIdByMiningPos(pos: string): Id<Source> {
-        return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-            ([sourceId, miningPos]) => pos === miningPos
-        )?.[0] as Id<Source>;
+    private getSourceId(): Id<Source>{
+        if(Game.rooms[this.memory.assignment.toRoomPos().roomName]){
+            let id = this.memory.assignment.toRoomPos().findInRange(FIND_SOURCES, 1)?.pop().id;
+            this.memory.targetId = id;
+            return id;
+        }
+    }
+
+    private getContainerId(): Id<Structure>{
+        
+        if(this.memory.targetId){
+            return this.memory.targetId as Id<Structure>;
+        }
+        
+        if(Game.rooms[this.memory.assignment.toRoomPos().roomName]){
+            let id = this.memory.assignment.toRoomPos().lookFor(LOOK_STRUCTURES).find(s => s.structureType === STRUCTURE_CONTAINER)?.id;
+            return id;
+        }
     }
 }

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -1,5 +1,4 @@
 import { isKeeperRoom } from '../modules/data';
-import { posFromMem } from '../modules/data';
 import { Pathing } from '../modules/pathing';
 import { TransportCreep } from '../virtualCreeps/transportCreep';
 
@@ -57,7 +56,7 @@ export class Gatherer extends TransportCreep {
                 (this.onEdge() || this.pos.isNearTo(Game.getObjectById(this.memory.storeRoadInMemory)))
         );
         // Going back to storage
-        if (posFromMem(this.memory._m.destination)?.roomName === this.memory.room) {
+        if (this.memory._m.destination?.toRoomPos()?.roomName === this.memory.room) {
             this.storeRoadInMemory(roomPositions);
         }
 
@@ -174,7 +173,7 @@ export class Gatherer extends TransportCreep {
         const targets: { id: Id<Resource> | Id<Structure> | Id<Tombstone>; amount: number }[] = [];
 
         Object.values(miningPositions).forEach((posString) => {
-            const pos = posFromMem(posString);
+            const pos = posString.toRoomPos();
             const areaInRange = Pathing.getArea(pos, 3);
             const lookArea = Game.rooms[roomName].lookAtArea(areaInRange.top, areaInRange.left, areaInRange.bottom, areaInRange.right, true);
             if (

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -5,7 +5,7 @@ import { TransportCreep } from '../virtualCreeps/transportCreep';
 
 export class Gatherer extends TransportCreep {
     protected run() {
-        if (this.memory?.spawnReplacementAt === Game.time) {
+        if (this.memory?.spawnReplacementAt >= Game.time && this.homeroom.memory.remoteSources[this.memory.assignment].gatherers.includes(this.name)) {
             this.triggerReplacementSpawn();
         }
 
@@ -114,7 +114,6 @@ export class Gatherer extends TransportCreep {
         const COMPLETION_OF_LAST_TRIP = Game.time + TRIPS_REMAINING * TRIP_LENGTH;
         const START_SPAWNING_REPLACEMENT_AT = COMPLETION_OF_LAST_TRIP - TICKS_TO_SPAWN;
         const SPAWN_CYCLES_REMAINING = Math.floor(TRIPS_REMAINING / TRIPS_PER_SPAWN_CYCLE);
-        this.say(TRIPS_REMAINING.toString());
 
         //determine when to spawn replacement toward end of lifecycle
         if (TRIPS_REMAINING === 0) {

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -5,7 +5,7 @@ import { TransportCreep } from '../virtualCreeps/transportCreep';
 
 export class Gatherer extends TransportCreep {
     protected run() {
-        if (this.damaged() || Memory.remoteData[this.memory.assignment]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
+        if (this.damaged() || Memory.remoteData[this.memory.assignment.toRoomPos().roomName]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
             delete this.memory.targetId;
             this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
             return;

--- a/src/roles/gatherer.ts
+++ b/src/roles/gatherer.ts
@@ -125,7 +125,6 @@ export class Gatherer extends TransportCreep {
     }
 
     private triggerReplacementSpawn() {
-        console.log('Replacing ' + this.name);
         for (let i = 0; i < this.homeroom.memory.remoteSources[this.memory.assignment].gatherers.length; i++) {
             if (this.homeroom.memory.remoteSources[this.memory.assignment].gatherers[i] === this.name) {
                 this.homeroom.memory.remoteSources[this.memory.assignment].gatherers[i] === AssignmentStatus.UNASSIGNED;

--- a/src/roles/keeperExterminator.ts
+++ b/src/roles/keeperExterminator.ts
@@ -1,86 +1,86 @@
 import { CombatCreep } from '../virtualCreeps/combatCreep';
 
 export class KeeperExterminator extends CombatCreep {
-    private attacked: boolean = false;
-    protected run() {
-        let target = Game.getObjectById(this.memory.targetId);
-        if (this.room.name === this.memory.assignment || target) {
-            if (!target) {
-                this.memory.targetId = this.findTarget();
-                target = Game.getObjectById(this.memory.targetId);
-            }
+    // private attacked: boolean = false;
+    // protected run() {
+    //     let target = Game.getObjectById(this.memory.targetId);
+    //     if (this.room.name === this.memory.assignment || target) {
+    //         if (!target) {
+    //             this.memory.targetId = this.findTarget();
+    //             target = Game.getObjectById(this.memory.targetId);
+    //         }
 
-            if (target instanceof ConstructionSite) {
-                let miner = Game.creeps[Memory.remoteData[this.memory.assignment].miner];
-                //scan area for keeper
-                let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
-                if (keeper && this.pos.isNearTo(keeper)) {
-                    this.attackCreep(keeper);
-                } else if (miner?.memory.destination !== target.pos.toMemSafe() || !miner?.pos.isNearTo(target.pos)) {
-                    this.travelTo(target.pos, { avoidSourceKeepers: false });
-                } else {
-                    const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-                        ([sourceId, miningPos]) => target.pos.toMemSafe() === miningPos
-                    );
-                    const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[sourceId[0]] as Id<Structure<StructureConstant>>;
-                    this.travelTo(Game.getObjectById(lairId), { range: 1, avoidSourceKeepers: false });
-                }
-            } else if (target instanceof Structure) {
-                if (!this.pos.isNearTo(target)) {
-                    this.travelTo(target, { range: 1, avoidSourceKeepers: false });
-                }
+    //         if (target instanceof ConstructionSite) {
+    //             let miner = Game.creeps[Memory.remoteData[this.memory.assignment].miner];
+    //             //scan area for keeper
+    //             let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
+    //             if (keeper && this.pos.isNearTo(keeper)) {
+    //                 this.attackCreep(keeper);
+    //             } else if (miner?.memory.destination !== target.pos.toMemSafe() || !miner?.pos.isNearTo(target.pos)) {
+    //                 this.travelTo(target.pos, { avoidSourceKeepers: false });
+    //             } else {
+    //                 const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
+    //                     ([sourceId, miningPos]) => target.pos.toMemSafe() === miningPos
+    //                 );
+    //                 const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[sourceId[0]] as Id<Structure<StructureConstant>>;
+    //                 this.travelTo(Game.getObjectById(lairId), { range: 1, avoidSourceKeepers: false });
+    //             }
+    //         } else if (target instanceof Structure) {
+    //             if (!this.pos.isNearTo(target)) {
+    //                 this.travelTo(target, { range: 1, avoidSourceKeepers: false });
+    //             }
 
-                //scan area for keeper
-                let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
-                if (keeper) {
-                    this.memory.targetId = keeper.id;
-                }
-            } else if (target instanceof Creep) {
-                if (this.pos.isNearTo(target)) {
-                    this.attackCreep(target as Creep);
-                    this.attacked = true;
-                    this.move(this.pos.getDirectionTo(target)); // Stay in range if the enemy creep moves
-                } else {
-                    this.travelTo(target, { range: 1, avoidSourceKeepers: false });
-                }
-            }
+    //             //scan area for keeper
+    //             let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
+    //             if (keeper) {
+    //                 this.memory.targetId = keeper.id;
+    //             }
+    //         } else if (target instanceof Creep) {
+    //             if (this.pos.isNearTo(target)) {
+    //                 this.attackCreep(target as Creep);
+    //                 this.attacked = true;
+    //                 this.move(this.pos.getDirectionTo(target)); // Stay in range if the enemy creep moves
+    //             } else {
+    //                 this.travelTo(target, { range: 1, avoidSourceKeepers: false });
+    //             }
+    //         }
 
-            if (!this.attacked) {
-                this.heal(this);
-            }
-        } else {
-            this.travelToRoom(this.memory.assignment);
-        }
-    }
+    //         if (!this.attacked) {
+    //             this.heal(this);
+    //         }
+    //     } else {
+    //         this.travelToRoom(this.memory.assignment);
+    //     }
+    // }
 
-    private findTarget(): Id<Creep> | Id<Structure> | Id<ConstructionSite> {
-        let containerConstructionSite = Game.rooms[this.memory.assignment]
-            ?.find(FIND_MY_CONSTRUCTION_SITES, { filter: (site) => site.structureType === STRUCTURE_CONTAINER })
-            .shift();
-        if (containerConstructionSite) {
-            return containerConstructionSite.id;
-        }
+    // private findTarget(): Id<Creep> | Id<Structure> | Id<ConstructionSite> {
+    //     let containerConstructionSite = Game.rooms[this.memory.assignment]
+    //         ?.find(FIND_MY_CONSTRUCTION_SITES, { filter: (site) => site.structureType === STRUCTURE_CONTAINER })
+    //         .shift();
+    //     if (containerConstructionSite) {
+    //         return containerConstructionSite.id;
+    //     }
 
-        let invaders = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, {
-            filter: (c) =>
-                c.getActiveBodyparts(ATTACK) > 0 ||
-                ((c.getActiveBodyparts(RANGED_ATTACK) || c.getActiveBodyparts(HEAL) > 0) && c.owner.username !== 'Source Keeper'),
-        });
-        if (invaders?.length) {
-            return this.pos.findClosestByPath(invaders)?.id || this.pos.findClosestByRange(invaders)?.id;
-        }
+    //     let invaders = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, {
+    //         filter: (c) =>
+    //             c.getActiveBodyparts(ATTACK) > 0 ||
+    //             ((c.getActiveBodyparts(RANGED_ATTACK) || c.getActiveBodyparts(HEAL) > 0) && c.owner.username !== 'Source Keeper'),
+    //     });
+    //     if (invaders?.length) {
+    //         return this.pos.findClosestByPath(invaders)?.id || this.pos.findClosestByRange(invaders)?.id;
+    //     }
 
-        let keepers = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, { filter: (c) => c.owner.username === 'Source Keeper' });
-        if (keepers?.length) {
-            return this.pos.findClosestByPath(keepers)?.id || this.pos.findClosestByRange(keepers)?.id;
-        }
+    //     let keepers = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, { filter: (c) => c.owner.username === 'Source Keeper' });
+    //     if (keepers?.length) {
+    //         return this.pos.findClosestByPath(keepers)?.id || this.pos.findClosestByRange(keepers)?.id;
+    //     }
 
-        let lairs = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) =>
-            Game.getObjectById(lairId)
-        ) as StructureKeeperLair[];
-        let nextSpawn = lairs?.reduce((lowestTimer, next) => (lowestTimer?.ticksToSpawn <= next?.ticksToSpawn ? lowestTimer : next));
-        if (nextSpawn) {
-            return nextSpawn.id;
-        }
-    }
+    //     let lairs = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) =>
+    //         Game.getObjectById(lairId)
+    //     ) as StructureKeeperLair[];
+    //     let nextSpawn = lairs?.reduce((lowestTimer, next) => (lowestTimer?.ticksToSpawn <= next?.ticksToSpawn ? lowestTimer : next));
+    //     if (nextSpawn) {
+    //         return nextSpawn.id;
+    //     }
+    // }
 }

--- a/src/roles/keeperExterminator.ts
+++ b/src/roles/keeperExterminator.ts
@@ -1,86 +1,89 @@
 import { CombatCreep } from '../virtualCreeps/combatCreep';
 
 export class KeeperExterminator extends CombatCreep {
-    // private attacked: boolean = false;
-    // protected run() {
-    //     let target = Game.getObjectById(this.memory.targetId);
-    //     if (this.room.name === this.memory.assignment || target) {
-    //         if (!target) {
-    //             this.memory.targetId = this.findTarget();
-    //             target = Game.getObjectById(this.memory.targetId);
-    //         }
+    private attacked: boolean = false;
+    protected run() {
+        let target = Game.getObjectById(this.memory.targetId);
+        if (this.room.name === this.memory.assignment || target) {
+            if (!target) {
+                this.memory.targetId = this.findTarget();
+                target = Game.getObjectById(this.memory.targetId);
+            }
+            //if destination is set, then miningPosition construction site needs defended
+            if (this.memory.destination) {
+                let target = this.pos.findInRange(FIND_HOSTILE_CREEPS, 1)?.pop();
+                if (target) {
+                    this.attack(target);
+                }
+                delete this.memory.destination;
+            } else {
+                if (target instanceof Structure) {
+                    if (!this.pos.isNearTo(target)) {
+                        this.travelTo(target, { range: 1, avoidSourceKeepers: false });
+                    }
 
-    //         if (target instanceof ConstructionSite) {
-    //             let miner = Game.creeps[Memory.remoteData[this.memory.assignment].miner];
-    //             //scan area for keeper
-    //             let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
-    //             if (keeper && this.pos.isNearTo(keeper)) {
-    //                 this.attackCreep(keeper);
-    //             } else if (miner?.memory.destination !== target.pos.toMemSafe() || !miner?.pos.isNearTo(target.pos)) {
-    //                 this.travelTo(target.pos, { avoidSourceKeepers: false });
-    //             } else {
-    //                 const sourceId = Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-    //                     ([sourceId, miningPos]) => target.pos.toMemSafe() === miningPos
-    //                 );
-    //                 const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[sourceId[0]] as Id<Structure<StructureConstant>>;
-    //                 this.travelTo(Game.getObjectById(lairId), { range: 1, avoidSourceKeepers: false });
-    //             }
-    //         } else if (target instanceof Structure) {
-    //             if (!this.pos.isNearTo(target)) {
-    //                 this.travelTo(target, { range: 1, avoidSourceKeepers: false });
-    //             }
+                    //scan area for keeper
+                    let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
+                    if (keeper) {
+                        this.memory.targetId = keeper.id;
+                    }
+                } else if (target instanceof Creep) {
+                    if (this.pos.isNearTo(target)) {
+                        this.attackCreep(target as Creep);
+                        this.attacked = true;
+                        this.move(this.pos.getDirectionTo(target)); // Stay in range if the enemy creep moves
+                    } else {
+                        this.travelTo(target, { range: 1, avoidSourceKeepers: false });
+                    }
+                }
+                if (!this.attacked) {
+                    this.heal(this);
+                }
+            }
+        } else {
+            this.travelToRoom(this.memory.assignment);
+        }
+    }
 
-    //             //scan area for keeper
-    //             let keeper = target.pos.findInRange(FIND_HOSTILE_CREEPS, 5, { filter: (c) => c.owner.username === 'Source Keeper' }).shift();
-    //             if (keeper) {
-    //                 this.memory.targetId = keeper.id;
-    //             }
-    //         } else if (target instanceof Creep) {
-    //             if (this.pos.isNearTo(target)) {
-    //                 this.attackCreep(target as Creep);
-    //                 this.attacked = true;
-    //                 this.move(this.pos.getDirectionTo(target)); // Stay in range if the enemy creep moves
-    //             } else {
-    //                 this.travelTo(target, { range: 1, avoidSourceKeepers: false });
-    //             }
-    //         }
+    private findTarget(): Id<Creep> | Id<Structure> | Id<ConstructionSite> {
+        let sourcesMined = Object.keys(Memory.remoteSourceAssignments).filter((key) => key.split('.')[2] === this.memory.assignment);
 
-    //         if (!this.attacked) {
-    //             this.heal(this);
-    //         }
-    //     } else {
-    //         this.travelToRoom(this.memory.assignment);
-    //     }
-    // }
+        let invaders = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, {
+            filter: (c) =>
+                c.getActiveBodyparts(ATTACK) > 0 ||
+                ((c.getActiveBodyparts(RANGED_ATTACK) || c.getActiveBodyparts(HEAL) > 0) && c.owner.username !== 'Source Keeper'),
+        });
+        if (invaders?.length) {
+            return this.pos.findClosestByPath(invaders)?.id || this.pos.findClosestByRange(invaders)?.id;
+        }
 
-    // private findTarget(): Id<Creep> | Id<Structure> | Id<ConstructionSite> {
-    //     let containerConstructionSite = Game.rooms[this.memory.assignment]
-    //         ?.find(FIND_MY_CONSTRUCTION_SITES, { filter: (site) => site.structureType === STRUCTURE_CONTAINER })
-    //         .shift();
-    //     if (containerConstructionSite) {
-    //         return containerConstructionSite.id;
-    //     }
+        let threats = [];
+        sourcesMined.forEach((source) => {
+            let sourceMemory = Memory.rooms[Memory.remoteSourceAssignments[source].controllingRoom].remoteSources[source];
+            if (
+                (sourceMemory.setupStatus === RemoteSourceSetupStatus.BUILDING_CONTAINER && sourceMemory.miner === AssignmentStatus.UNASSIGNED) ||
+                Game.creeps[sourceMemory.miner].pos.inRangeTo(sourceMemory.miningPos.toRoomPos(), 1)
+            ) {
+                this.memory.destination = sourceMemory.miningPos;
+                return;
+            }
 
-    //     let invaders = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, {
-    //         filter: (c) =>
-    //             c.getActiveBodyparts(ATTACK) > 0 ||
-    //             ((c.getActiveBodyparts(RANGED_ATTACK) || c.getActiveBodyparts(HEAL) > 0) && c.owner.username !== 'Source Keeper'),
-    //     });
-    //     if (invaders?.length) {
-    //         return this.pos.findClosestByPath(invaders)?.id || this.pos.findClosestByRange(invaders)?.id;
-    //     }
+            let threat = source.toRoomPos().findInRange(FIND_HOSTILE_CREEPS, 5)?.pop();
+            if (threat) {
+                threats.push(threat);
+            }
+        });
 
-    //     let keepers = Game.rooms[this.memory.assignment]?.find(FIND_HOSTILE_CREEPS, { filter: (c) => c.owner.username === 'Source Keeper' });
-    //     if (keepers?.length) {
-    //         return this.pos.findClosestByPath(keepers)?.id || this.pos.findClosestByRange(keepers)?.id;
-    //     }
+        if (threats.length) {
+            return this.pos.findClosestByPath(threats)?.id;
+        }
 
-    //     let lairs = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) =>
-    //         Game.getObjectById(lairId)
-    //     ) as StructureKeeperLair[];
-    //     let nextSpawn = lairs?.reduce((lowestTimer, next) => (lowestTimer?.ticksToSpawn <= next?.ticksToSpawn ? lowestTimer : next));
-    //     if (nextSpawn) {
-    //         return nextSpawn.id;
-    //     }
-    // }
+        let lairs = Object.keys(Memory.remoteData[this.memory.assignment].sourceKeeperLairs)
+            .filter((key) => Memory.remoteSourceAssignments[key])
+            .map((key) => Game.getObjectById(Memory.remoteData[this.memory.assignment].sourceKeeperLairs[key])) as StructureKeeperLair[];
+        let nextSpawn = lairs?.reduce((lowestTimer, next) => (lowestTimer?.ticksToSpawn <= next?.ticksToSpawn ? lowestTimer : next));
+        if (nextSpawn) {
+            return nextSpawn.id;
+        }
+    }
 }

--- a/src/roles/manager.ts
+++ b/src/roles/manager.ts
@@ -152,17 +152,17 @@ export class Manager extends WaveCreep {
         }
 
         let res = this.getResourceToTransferToTerminal();
-        if (res) {
-            this.withdraw(storage, res, Math.min(storage.store[res], 5000 - terminal.store[res], this.store.getFreeCapacity()));
+        if (terminal && res) {
+            this.withdraw(storage, res, Math.min(storage.store[res], 5000 - terminal?.store[res], this.store.getFreeCapacity()));
             this.memory.targetId = terminal.id;
             return;
         }
 
         let remRes = this.getResourceToRemoveFromTerminal();
-        if (remRes) {
+        if (terminal && remRes) {
             let amount = MINERAL_COMPOUNDS.includes(remRes)
                 ? Math.min(terminal.store[remRes] - 5000, this.store.getFreeCapacity())
-                : Math.min(this.store.getFreeCapacity(), terminal.store[remRes]);
+                : Math.min(this.store.getFreeCapacity(), terminal?.store[remRes]);
             this.withdraw(terminal, remRes, amount);
             this.memory.targetId = storage.id;
             return;

--- a/src/roles/manager.ts
+++ b/src/roles/manager.ts
@@ -1,4 +1,3 @@
-import { posFromMem } from '../modules/data';
 import { getFactoryResourcesNeeded, shipmentReady } from '../modules/resourceManagement';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
@@ -9,7 +8,7 @@ export class Manager extends WaveCreep {
 
     protected run() {
         const managerPos =
-            this.room.memory.layout === RoomLayout.STAMP ? posFromMem(this.memory.destination) : posFromMem(this.room.memory?.managerPos);
+            this.room.memory.layout === RoomLayout.STAMP ? this.memory.destination.toRoomPos() : this.room.memory?.managerPos.toRoomPos();
         const isCenterStampManager =
             this.room.memory.layout === RoomLayout.STAMP &&
             this.room.stamps.managers.some(

--- a/src/roles/manager.ts
+++ b/src/roles/manager.ts
@@ -8,7 +8,7 @@ export class Manager extends WaveCreep {
 
     protected run() {
         const managerPos =
-            this.room.memory.layout === RoomLayout.STAMP ? this.memory.destination.toRoomPos() : this.room.memory?.managerPos.toRoomPos();
+            this.room.memory.layout === RoomLayout.STAMP ? this.memory.destination?.toRoomPos() : this.room.memory?.managerPos?.toRoomPos();
         const isCenterStampManager =
             this.room.memory.layout === RoomLayout.STAMP &&
             this.room.stamps.managers.some(

--- a/src/roles/miner.ts
+++ b/src/roles/miner.ts
@@ -1,9 +1,8 @@
-import { posFromMem } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class Miner extends WaveCreep {
     protected run() {
-        let assignedPos = posFromMem(this.memory.assignment);
+        let assignedPos = this.memory.assignment.toRoomPos();
         if (this.pos.isEqualTo(assignedPos)) {
             this.memory.currentTaskPriority = Priority.HIGH;
 

--- a/src/roles/mineralMiner.ts
+++ b/src/roles/mineralMiner.ts
@@ -1,9 +1,8 @@
-import { posFromMem } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class MineralMiner extends WaveCreep {
     protected run() {
-        let assignedPos = posFromMem(this.memory.assignment);
+        let assignedPos = this.memory.assignment.toRoomPos();
         if (this.pos.isEqualTo(assignedPos)) {
             this.memory.currentTaskPriority = Priority.HIGH;
             let container = this.pos.lookFor(LOOK_STRUCTURES).find((s) => s.structureType === STRUCTURE_CONTAINER) as StructureContainer;

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -14,9 +14,11 @@ export class RemoteMiner extends WaveCreep {
         if (Game.rooms[this.getMiningPosition().roomName]) {
             const isAKeeperRoom = isKeeperRoom(this.memory.assignment.toRoomPos().roomName);
             if (isAKeeperRoom && this.keeperSpawning()) {
-                const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
-                    return { pos: Game.getObjectById(lairId).pos, range: 0 };
-                });
+                const lairPositions = Object.values(Memory.remoteData[this.memory.assignment.toRoomPos().roomName].sourceKeeperLairs).map(
+                    (lairId) => {
+                        return { pos: Game.getObjectById(lairId).pos, range: 0 };
+                    }
+                );
                 if (this.onEdge()) {
                     this.travelToRoom(this.memory.assignment.toRoomPos().roomName); // Prevent going in and out of the room
                 } else {
@@ -63,7 +65,7 @@ export class RemoteMiner extends WaveCreep {
     }
 
     private keeperSpawning(): boolean {
-        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceId()];
+        const lairId = Memory.remoteData[this.memory.assignment.toRoomPos().roomName].sourceKeeperLairs[this.getSourceId()];
         const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
         return lairInRange?.ticksToSpawn < 20;
     }

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -44,10 +44,10 @@ export class RemoteMiner extends WaveCreep {
                         if(this.homeroom.memory.remoteSources[source.pos.toMemSafe()].setupStatus === RemoteSourceSetupStatus.BUILDING_CONTAINER){
                             this.homeroom.memory.remoteSources[source.pos.toMemSafe()].setupStatus = RemoteSourceSetupStatus.BUILDING_ROAD;
                         }
-                        if(source.energy && (container.store.getFreeCapacity() || this.store.getFreeCapacity())){
-                            this.harvest(source);
-                        } else if (container.hits < container.hitsMax){
+                        if (this.store.energy && container.hits < container.hitsMax){
                             this.repair(container);
+                        } else if(source.energy && (container.store.getFreeCapacity() || this.store.getFreeCapacity())){
+                            this.harvest(source);
                         } else {
                             this.say('...');
                         }

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -2,6 +2,9 @@ import { isKeeperRoom } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 export class RemoteMiner extends WaveCreep {
     protected run() {
+        if(Game.time === this.memory.spawnReplacementAt){
+            this.homeroom.memory.remoteSources[this.memory.assignment].miner = AssignmentStatus.UNASSIGNED;
+        }
         if (
             this.damaged() ||
             Memory.remoteData[this.memory.assignment.toRoomPos().roomName]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS
@@ -80,6 +83,7 @@ export class RemoteMiner extends WaveCreep {
         }
 
         if (Game.rooms[this.memory.assignment.toRoomPos().roomName]) {
+            this.manageLifecycle(); //this is only reached once and is only called once creep is at miningPos
             let id = this.memory.assignment.toRoomPos().lookFor(LOOK_SOURCES)?.pop().id;
             this.memory.targetId = id;
             return id;
@@ -88,5 +92,9 @@ export class RemoteMiner extends WaveCreep {
 
     private getMiningPosition(): RoomPosition {
         return this.homeroom.memory.remoteSources[this.memory.assignment].miningPos.toRoomPos();
+    }
+
+    private manageLifecycle(): void{
+        this.memory.spawnReplacementAt = Game.time + this.ticksToLive - this.body.length * 3 - Memory.remoteSourceAssignments[this.memory.assignment].roadLength;
     }
 }

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -8,83 +8,10 @@ export class RemoteMiner extends WaveCreep {
         }
 
         //if we have visibility in assigned room
-        if (Game.rooms[this.memory.assignment]) {
-            // Remove left over extensions (usually from strongholds) when these block creation of new extensions
-            if (this.memory.targetId) {
-                const structure = Game.getObjectById(this.memory.targetId) as StructureContainer;
-                if (!structure) {
-                    delete this.memory.targetId;
-                } else {
-                    const dismantleStatus = this.dismantle(structure);
-                    if (dismantleStatus === ERR_NOT_IN_RANGE) {
-                        this.travelTo(structure);
-                    }
-                    return;
-                }
-            }
+        if (Game.rooms[this.memory.assignment.toRoomPos().roomName]) {
 
-            const isAKeeperRoom = isKeeperRoom(this.memory.assignment);
-            if (!this.memory.destination) {
-                this.memory.destination = this.findNextMiningPos(isAKeeperRoom);
-            }
-
-            let targetPos = this.memory.destination.toRoomPos();
-            if (targetPos) {
-                if (!this.pos.isEqualTo(targetPos)) {
-                    if (isAKeeperRoom && this.destinationSpawningKeeper(this.memory.destination)) {
-                        delete this.memory.destination;
-                    } else {
-                        this.travelTo(targetPos);
-                    }
-                } else {
-                    let container: StructureContainer = targetPos
-                        .lookFor(LOOK_STRUCTURES)
-                        .find((s) => s.structureType === STRUCTURE_CONTAINER) as StructureContainer;
-
-                    if (!container && this.store.energy) {
-                        let constructionSite = targetPos.lookFor(LOOK_CONSTRUCTION_SITES).find((s) => s.structureType === STRUCTURE_CONTAINER);
-                        if (!constructionSite) {
-                            const result = this.room.createConstructionSite(targetPos, STRUCTURE_CONTAINER);
-                            if (result === ERR_RCL_NOT_ENOUGH) {
-                                // left over extensions from a stronghold
-                                const structure = this.room
-                                    .find(FIND_STRUCTURES, {
-                                        filter: (s) =>
-                                            s.structureType === STRUCTURE_CONTAINER &&
-                                            !Object.keys(Memory.remoteData[this.memory.assignment]?.miningPositions)?.some(
-                                                (sourceId) => s.id === sourceId
-                                            ),
-                                    })
-                                    .shift();
-
-                                if (structure) {
-                                    this.memory.targetId = structure.id;
-                                }
-                            }
-                        } else if (this.store.energy) {
-                            this.build(constructionSite);
-                            return;
-                        }
-                    } else if (this.store.energy && container.hits < container.hitsMax) {
-                        this.repair(container);
-                    } else if (container?.store.getFreeCapacity() === 0) {
-                        delete this.memory.destination;
-                    } else {
-                        const source = Game.getObjectById(this.getSourceIdByMiningPos(this.memory.destination)) as Source;
-                        if (source && source.energy) {
-                            this.harvest(source);
-                        } else {
-                            delete this.memory.destination;
-                        }
-                    }
-
-                    if (isAKeeperRoom && container && (this.destinationSpawningKeeper(this.memory.destination) || this.hasKeeper(targetPos))) {
-                        this.say('🚨KEEPER🚨');
-                        delete this.memory.destination;
-                    }
-                }
-            } else if (isAKeeperRoom) {
-                //travel out of danger-zone
+            const isAKeeperRoom = isKeeperRoom(this.memory.assignment.toRoomPos().roomName);
+            if(isAKeeperRoom && this.keeperSpawning()){
                 const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
                     return { pos: Game.getObjectById(lairId).pos, range: 0 };
                 });
@@ -94,9 +21,37 @@ export class RemoteMiner extends WaveCreep {
                     this.travelTo(lairPositions.pop(), { range: 7, flee: true, goals: lairPositions, maxRooms: 1 }); // Travel out of harms way
                 }
             } else {
-                if (this.travelToRoom(this.memory.assignment) === IN_ROOM) {
-                    // Keep remote Miners from being around spawn
-                    this.say('🚚 is SLOW!');
+                if(!this.pos.isEqualTo(this.memory.assignment.toRoomPos())){
+                    this.travelTo(this.memory.assignment.toRoomPos());
+                } else {
+                    let container = this.pos.lookFor(LOOK_STRUCTURES).find(s => s.structureType === STRUCTURE_CONTAINER) as StructureContainer;
+                    if(!container){
+                        let site = this.pos.lookFor(LOOK_CONSTRUCTION_SITES).find(s => s.structureType === STRUCTURE_CONTAINER);
+                        if(site){
+                            if(this.store.energy >= this.getActiveBodyparts(WORK) * 5) {
+                                this.build(site);
+                            } else if(Game.getObjectById(this.getSourceId()).energy) {
+                                this.harvest(Game.getObjectById(this.getSourceId()));
+                            } else {
+                                this.say('...');
+                            }
+                        } else {
+                            this.pos.createConstructionSite(STRUCTURE_CONTAINER);
+                            this.homeroom.memory.remoteSources[Game.getObjectById(this.getSourceId()).pos.toMemSafe()].setupStatus = RemoteSourceSetupStatus.BUILDING_CONTAINER;
+                        }
+                    } else {
+                        let source = Game.getObjectById(this.getSourceId());
+                        if(this.homeroom.memory.remoteSources[source.pos.toMemSafe()].setupStatus === RemoteSourceSetupStatus.BUILDING_CONTAINER){
+                            this.homeroom.memory.remoteSources[source.pos.toMemSafe()].setupStatus = RemoteSourceSetupStatus.BUILDING_ROAD;
+                        }
+                        if(source.energy && (container.store.getFreeCapacity() || this.store.getFreeCapacity())){
+                            this.harvest(source);
+                        } else if (container.hits < container.hitsMax){
+                            this.repair(container);
+                        } else {
+                            this.say('...');
+                        }
+                    }
                 }
             }
         } else {
@@ -104,57 +59,25 @@ export class RemoteMiner extends WaveCreep {
         }
     }
 
-    private findNextMiningPos(isKeeperRoom: boolean): string {
-        const nextPos = Object.entries(Memory.remoteData[this.memory.assignment]?.miningPositions)?.find(([sourceId, miningPosString]) => {
-            const pos = miningPosString.toRoomPos();
-            if (isKeeperRoom) {
-                // LAIR
-                const lairId = Memory.remoteData[this.memory.assignment]?.sourceKeeperLairs[sourceId];
-                const lair = Game.getObjectById(lairId) as StructureKeeperLair;
-                const keeperSpawning = lair?.ticksToSpawn < 100;
-                if (keeperSpawning) {
-                    return false;
-                }
-
-                // KEEPER
-                const hasKeeper = !!pos.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
-                if (hasKeeper) {
-                    return false;
-                }
-            }
-
-            // ACTIVE SOURCE
-            const source = Game.getObjectById(sourceId) as Source;
-            if (!source.energy) {
-                return false;
-            }
-
-            // CONTAINER NOT FILLED
-            const container: StructureContainer = pos
-                .lookFor(LOOK_STRUCTURES)
-                .find((s) => s.structureType === STRUCTURE_CONTAINER) as StructureContainer;
-
-            return !(container?.store.getFreeCapacity() === 0);
-        });
-        if (!nextPos) {
-            return undefined;
-        }
-        return nextPos[1];
-    }
-
-    private destinationSpawningKeeper(pos: string): boolean {
-        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceIdByMiningPos(pos)];
+    private keeperSpawning(): boolean {
+        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getSourceId()];
         const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
         return lairInRange?.ticksToSpawn < 20;
     }
 
-    private getSourceIdByMiningPos(pos: string): Id<Source> {
-        return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-            ([sourceId, miningPos]) => pos === miningPos
-        )?.[0] as Id<Source>;
-    }
-
     private hasKeeper(target: RoomPosition): boolean {
         return !!target.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
+    }
+
+    private getSourceId(): Id<Source>{
+        if(this.memory.targetId){
+            return this.memory.targetId as Id<Source>;
+        }
+
+        if(Game.rooms[this.memory.assignment.toRoomPos().roomName]){
+            let id = this.memory.assignment.toRoomPos().findInRange(FIND_SOURCES, 1)?.pop().id;
+            this.memory.targetId = id;
+            return id;
+        }
     }
 }

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -1,5 +1,4 @@
 import { isKeeperRoom } from '../modules/data';
-import { posFromMem } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 export class RemoteMiner extends WaveCreep {
     protected run() {
@@ -29,7 +28,7 @@ export class RemoteMiner extends WaveCreep {
                 this.memory.destination = this.findNextMiningPos(isAKeeperRoom);
             }
 
-            let targetPos = posFromMem(this.memory.destination);
+            let targetPos = this.memory.destination.toRoomPos();
             if (targetPos) {
                 if (!this.pos.isEqualTo(targetPos)) {
                     if (isAKeeperRoom && this.destinationSpawningKeeper(this.memory.destination)) {
@@ -104,7 +103,7 @@ export class RemoteMiner extends WaveCreep {
 
     private findNextMiningPos(isKeeperRoom: boolean): string {
         const nextPos = Object.entries(Memory.remoteData[this.memory.assignment]?.miningPositions)?.find(([sourceId, miningPosString]) => {
-            const pos = posFromMem(miningPosString);
+            const pos = miningPosString.toRoomPos();
             if (isKeeperRoom) {
                 // LAIR
                 const lairId = Memory.remoteData[this.memory.assignment]?.sourceKeeperLairs[sourceId];

--- a/src/roles/remoteMiner.ts
+++ b/src/roles/remoteMiner.ts
@@ -2,7 +2,7 @@ import { isKeeperRoom } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 export class RemoteMiner extends WaveCreep {
     protected run() {
-        if (this.damaged() || Memory.remoteData[this.memory.assignment]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
+        if (this.damaged() || Memory.remoteData[this.memory.assignment.toRoomPos().roomName]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
             this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
             return;
         }

--- a/src/roles/remoteMineralMiner.ts
+++ b/src/roles/remoteMineralMiner.ts
@@ -2,104 +2,104 @@ import { isKeeperRoom } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class RemoteMineralMiner extends WaveCreep {
-    protected run() {
-        if (this.damaged() || Memory.remoteData[this.memory.assignment]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
-            this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
-            return;
-        }
+    // protected run() {
+    //     if (this.damaged() || Memory.remoteData[this.memory.assignment]?.threatLevel === RemoteRoomThreatLevel.ENEMY_ATTTACK_CREEPS) {
+    //         this.travelTo(new RoomPosition(25, 25, this.memory.room), { range: 22 }); // Travel back to home room
+    //         return;
+    //     }
 
-        // Store Cargo
-        if (this.memory.destination && this.memory.destination.toRoomPos().roomName === this.memory.room) {
-            this.storeCargo();
-            if (!this.store.getUsedCapacity()) {
-                const minTicks = isKeeperRoom(this.memory.assignment) ? 200 : 250;
-                if (this.ticksToLive < minTicks) {
-                    this.suicide(); // Can be changed to recycle once implemented
-                    return;
-                }
-                delete this.memory.destination;
-            }
-        } else if (Game.rooms[this.memory.assignment]) {
-            // Mining
-            const isAKeeperRoom = isKeeperRoom(this.memory.assignment);
-            if (!this.memory.destination) {
-                this.memory.destination = this.findTarget();
-            }
+    //     // Store Cargo
+    //     if (this.memory.destination && this.memory.destination.toRoomPos().roomName === this.memory.room) {
+    //         this.storeCargo();
+    //         if (!this.store.getUsedCapacity()) {
+    //             const minTicks = isKeeperRoom(this.memory.assignment) ? 200 : 250;
+    //             if (this.ticksToLive < minTicks) {
+    //                 this.suicide(); // Can be changed to recycle once implemented
+    //                 return;
+    //             }
+    //             delete this.memory.destination;
+    //         }
+    //     } else if (Game.rooms[this.memory.assignment]) {
+    //         // Mining
+    //         const isAKeeperRoom = isKeeperRoom(this.memory.assignment);
+    //         if (!this.memory.destination) {
+    //             this.memory.destination = this.findTarget();
+    //         }
 
-            let targetPos = this.memory.destination.toRoomPos();
-            if (targetPos) {
-                if (!this.pos.isEqualTo(targetPos)) {
-                    if (
-                        isAKeeperRoom &&
-                        this.pos.getRangeTo(targetPos) < 9 &&
-                        (this.hasKeeper(targetPos) || this.destinationSpawningKeeper(this.memory.destination))
-                    ) {
-                        this.say('🚨KEEPER🚨');
-                        delete this.memory.destination;
-                    } else {
-                        this.travelTo(targetPos);
-                    }
-                } else if (this.store.getFreeCapacity() >= this.getActiveBodyparts(WORK)) {
-                    if (isAKeeperRoom && (this.hasKeeper(targetPos) || this.destinationSpawningKeeper(this.memory.destination))) {
-                        this.say('🚨KEEPER🚨');
-                        delete this.memory.destination;
-                    } else {
-                        const mineral = Game.getObjectById(this.getMineralIdByMiningPos(this.memory.destination)) as Mineral;
-                        const result = this.harvest(mineral);
+    //         let targetPos = this.memory.destination.toRoomPos();
+    //         if (targetPos) {
+    //             if (!this.pos.isEqualTo(targetPos)) {
+    //                 if (
+    //                     isAKeeperRoom &&
+    //                     this.pos.getRangeTo(targetPos) < 9 &&
+    //                     (this.hasKeeper(targetPos) || this.destinationSpawningKeeper(this.memory.destination))
+    //                 ) {
+    //                     this.say('🚨KEEPER🚨');
+    //                     delete this.memory.destination;
+    //                 } else {
+    //                     this.travelTo(targetPos);
+    //                 }
+    //             } else if (this.store.getFreeCapacity() >= this.getActiveBodyparts(WORK)) {
+    //                 if (isAKeeperRoom && (this.hasKeeper(targetPos) || this.destinationSpawningKeeper(this.memory.destination))) {
+    //                     this.say('🚨KEEPER🚨');
+    //                     delete this.memory.destination;
+    //                 } else {
+    //                     const mineral = Game.getObjectById(this.getMineralIdByMiningPos(this.memory.destination)) as Mineral;
+    //                     const result = this.harvest(mineral);
 
-                        // Finished mining mineral
-                        if (result === ERR_NOT_ENOUGH_RESOURCES) {
-                            Memory.remoteData[this.memory.assignment].mineralAvailableAt = Game.time + mineral.ticksToRegeneration;
-                            this.suicide();
-                        }
-                    }
-                } else {
-                    // store cargo
-                    this.memory.destination = this.homeroom.storage.pos.toMemSafe();
-                }
+    //                     // Finished mining mineral
+    //                     if (result === ERR_NOT_ENOUGH_RESOURCES) {
+    //                         Memory.remoteData[this.memory.assignment].mineralAvailableAt = Game.time + mineral.ticksToRegeneration;
+    //                         this.suicide();
+    //                     }
+    //                 }
+    //             } else {
+    //                 // store cargo
+    //                 this.memory.destination = this.homeroom.storage.pos.toMemSafe();
+    //             }
 
-                //travel out of danger-zone
-                if (!this.memory.destination && isAKeeperRoom) {
-                    const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
-                        return { pos: Game.getObjectById(lairId).pos, range: 0 };
-                    });
-                    this.travelTo(targetPos, { range: 7, flee: true, goals: lairPositions }); // Travel back to home room
-                }
-            }
-        } else {
-            // Go to assignment room
-            this.travelToRoom(this.memory.assignment);
-        }
-    }
+    //             //travel out of danger-zone
+    //             if (!this.memory.destination && isAKeeperRoom) {
+    //                 const lairPositions = Object.values(Memory.remoteData[this.memory.assignment].sourceKeeperLairs).map((lairId) => {
+    //                     return { pos: Game.getObjectById(lairId).pos, range: 0 };
+    //                 });
+    //                 this.travelTo(targetPos, { range: 7, flee: true, goals: lairPositions }); // Travel back to home room
+    //             }
+    //         }
+    //     } else {
+    //         // Go to assignment room
+    //         this.travelToRoom(this.memory.assignment);
+    //     }
+    // }
 
-    private findTarget(): string {
-        const nextPos = Object.entries(Memory.remoteData[this.memory.assignment]?.miningPositions)?.find(([sourceId, miningPosString]) => {
-            // ACTIVE SOURCE
-            const source = Game.getObjectById(sourceId) as Mineral;
-            if (!source.mineralType) {
-                return false;
-            }
-            return true;
-        });
-        if (!nextPos || this.hasKeeper(nextPos[1].toRoomPos())) {
-            return undefined;
-        }
-        return nextPos[1];
-    }
+    // private findTarget(): string {
+    //     const nextPos = Object.entries(Memory.remoteData[this.memory.assignment]?.miningPositions)?.find(([sourceId, miningPosString]) => {
+    //         // ACTIVE SOURCE
+    //         const source = Game.getObjectById(sourceId) as Mineral;
+    //         if (!source.mineralType) {
+    //             return false;
+    //         }
+    //         return true;
+    //     });
+    //     if (!nextPos || this.hasKeeper(nextPos[1].toRoomPos())) {
+    //         return undefined;
+    //     }
+    //     return nextPos[1];
+    // }
 
-    private getMineralIdByMiningPos(pos: string): Id<Mineral> {
-        return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
-            ([sourceId, miningPos]) => pos === miningPos
-        )?.[0] as Id<Mineral>;
-    }
+    // private getMineralIdByMiningPos(pos: string): Id<Mineral> {
+    //     return Object.entries(Memory.remoteData[this.memory.assignment].miningPositions).find(
+    //         ([sourceId, miningPos]) => pos === miningPos
+    //     )?.[0] as Id<Mineral>;
+    // }
 
-    private destinationSpawningKeeper(pos: string): boolean {
-        const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getMineralIdByMiningPos(pos)];
-        const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
-        return lairInRange?.ticksToSpawn < 16;
-    }
+    // private destinationSpawningKeeper(pos: string): boolean {
+    //     const lairId = Memory.remoteData[this.memory.assignment].sourceKeeperLairs[this.getMineralIdByMiningPos(pos)];
+    //     const lairInRange = Game.getObjectById(lairId) as StructureKeeperLair;
+    //     return lairInRange?.ticksToSpawn < 16;
+    // }
 
-    private hasKeeper(target: RoomPosition): boolean {
-        return !!target.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
-    }
+    // private hasKeeper(target: RoomPosition): boolean {
+    //     return !!target.findInRange(FIND_HOSTILE_CREEPS, 3, { filter: (c) => c.owner.username === 'Source Keeper' }).length;
+    // }
 }

--- a/src/roles/remoteMineralMiner.ts
+++ b/src/roles/remoteMineralMiner.ts
@@ -1,4 +1,4 @@
-import { isKeeperRoom, posFromMem } from '../modules/data';
+import { isKeeperRoom } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class RemoteMineralMiner extends WaveCreep {
@@ -9,7 +9,7 @@ export class RemoteMineralMiner extends WaveCreep {
         }
 
         // Store Cargo
-        if (this.memory.destination && posFromMem(this.memory.destination).roomName === this.memory.room) {
+        if (this.memory.destination && this.memory.destination.toRoomPos().roomName === this.memory.room) {
             this.storeCargo();
             if (!this.store.getUsedCapacity()) {
                 const minTicks = isKeeperRoom(this.memory.assignment) ? 200 : 250;
@@ -26,7 +26,7 @@ export class RemoteMineralMiner extends WaveCreep {
                 this.memory.destination = this.findTarget();
             }
 
-            let targetPos = posFromMem(this.memory.destination);
+            let targetPos = this.memory.destination.toRoomPos();
             if (targetPos) {
                 if (!this.pos.isEqualTo(targetPos)) {
                     if (
@@ -81,7 +81,7 @@ export class RemoteMineralMiner extends WaveCreep {
             }
             return true;
         });
-        if (!nextPos || this.hasKeeper(posFromMem(nextPos[1]))) {
+        if (!nextPos || this.hasKeeper(nextPos[1].toRoomPos())) {
             return undefined;
         }
         return nextPos[1];

--- a/src/roles/reserver.ts
+++ b/src/roles/reserver.ts
@@ -1,4 +1,3 @@
-import { posFromMem } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class Reserver extends WaveCreep {
@@ -14,7 +13,7 @@ export class Reserver extends WaveCreep {
                 this.memory.destination = targetRoom.controller.pos.toMemSafe();
             }
         } else {
-            let targetPos = posFromMem(this.memory.destination);
+            let targetPos = this.memory.destination.toRoomPos();
             if (!this.pos.isNearTo(targetPos)) {
                 this.travelTo(targetPos, { range: 1 });
                 return;

--- a/src/roles/scout.ts
+++ b/src/roles/scout.ts
@@ -1,4 +1,3 @@
-import { posFromMem } from '../modules/data';
 import { WaveCreep } from '../virtualCreeps/waveCreep';
 
 export class Scout extends WaveCreep {
@@ -115,7 +114,7 @@ export class Scout extends WaveCreep {
      */
     private getPath(target: RoomPosition): PathFinderPath {
         return PathFinder.search(
-            posFromMem(this.memory.scout.spawn),
+            this.memory.scout.spawn.toRoomPos(),
             { pos: target, range: 1 },
             { plainCost: 1, swampCost: 2, maxCost: this.homeroom.controller.level < 7 ? 70 : 90 }
         );

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -1,7 +1,7 @@
 import { WaveCreep } from './waveCreep';
 
 export class TransportCreep extends WaveCreep {
-    private previousTargetId: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> | Id<Mineral>;
+    private previousTargetId: Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> | Id<Mineral> | Id<Source>;
     protected incomingEnergyAmount: number = 0; // Picked up energy in same tick to do proper retargeting
     protected incomingMineralAmount: number = 0; // Picked up non-energy in same tick to do proper retargeting
     protected outgoingResourceAmount: number = 0; // Dropped off energy in the same tick to do proper retargeting

--- a/src/virtualCreeps/waveCreep.ts
+++ b/src/virtualCreeps/waveCreep.ts
@@ -1,5 +1,3 @@
-import { posFromMem } from '../modules/data';
-
 export class WaveCreep extends Creep {
     private static priorityQueue: Map<string, (creep: Creep) => void> = new Map();
     public drive() {
@@ -9,7 +7,7 @@ export class WaveCreep extends Creep {
         if (this.memory.needsBoosted) {
             this.getNextBoost();
         } else if (this.memory.portalLocations?.[0]) {
-            let portalPos = posFromMem(this.memory.portalLocations[0]);
+            let portalPos = this.memory.portalLocations[0].toRoomPos();
 
             if (!this.pos.isNearTo(portalPos)) {
                 this.travelTo(portalPos);

--- a/src/virtualCreeps/workerCreep.ts
+++ b/src/virtualCreeps/workerCreep.ts
@@ -114,7 +114,7 @@ export class WorkerCreep extends WaveCreep {
     }
 
     protected runBuildJob(target: ConstructionSite) {
-        this.memory.currentTaskPriority = Priority.MEDIUM;
+        this.memory.currentTaskPriority = Priority.LOW;
         let jobCost = BUILD_POWER * this.getActiveBodyparts(WORK);
         let buildSuccess = this.build(target);
         switch (buildSuccess) {
@@ -139,7 +139,7 @@ export class WorkerCreep extends WaveCreep {
     }
 
     protected runUpgradeJob() {
-        this.memory.currentTaskPriority = Priority.MEDIUM;
+        this.memory.currentTaskPriority = Priority.LOW;
         let jobCost = UPGRADE_CONTROLLER_POWER * this.getActiveBodyparts(WORK);
         switch (this.upgradeController(this.homeroom.controller)) {
             case ERR_NOT_IN_RANGE:
@@ -165,7 +165,7 @@ export class WorkerCreep extends WaveCreep {
     }
 
     protected runRepairJob(target: Structure) {
-        this.memory.currentTaskPriority = Priority.MEDIUM;
+        this.memory.currentTaskPriority = Priority.LOW;
         if (target.hits < target.hitsMax) {
             let jobCost = REPAIR_COST * REPAIR_POWER * this.getActiveBodyparts(WORK);
             let repairSuccess = this.repair(target);


### PR DESCRIPTION
This will change how we remote mine - rather than claiming entire rooms to remote mine, owned rooms will now claim remote sources instead and use high-precision calculations to estimate income gained from source. With improved spawn timings and creep behaviors, we can reach nearly 100% efficiency on sources being mined.

Additionally, adds a new memory tool - roads. Roads are paths from one position to another, stored in roomData of all rooms through which they pass as a string. The  roads module includes many helper functions to work with road data. Using roads like this will allow us to lessen dependency on dynamic pathfinding and potentially greatly improve our CPU efficiency for repetitive tasks. The new remote miners and gathers make extensive use of this feature.

Before this is deployed to your account, make sure to purge all remote room data and remote room assignments from memory - not reverse compatible with prior operations.