### PR TITLE
Cpu improvement

### DIFF
--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -13,6 +13,11 @@ interface Memory {
     remoteSourceClaims?: { [sourcePos: string]: { claimant: string; estimatedIncome: number } }; //map of potential remote rooms to rooms intending to claim them and their anticipated net income - higher income gets priority
     remoteSourceAssignments?: { [sourcePos: string]: RemoteAssignmentData }; //maps sources in other rooms to owned rooms mining them
     debug?: DebugSettings;
+    cpuUsage: CpuUsage;
+}
+
+interface CpuUsage {
+    average: number;
 }
 
 interface EmpireIntershard {
@@ -173,6 +178,8 @@ interface DebugSettings {
     drawRoads?: boolean;
     drawRemoteConnections?: boolean;
     logRoomPlacementCpu?: boolean;
+    logRoomCpu?: boolean;
+    logCreepCpu?: boolean;
 }
 
 interface RemoteAssignmentData {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -95,7 +95,6 @@ interface Room {
     factory: StructureFactory;
     observer: StructureObserver;
     powerSpawn: StructurePowerSpawn;
-    stamps: Stamps;
     remoteMiningRooms: string[];
     remoteSources: string[];
 }
@@ -127,7 +126,7 @@ interface Stamps {
 interface StampDetail {
     type?: string; // Can differentiate if needed (center vs miner extensions)
     rcl: number; // Indicator at what rcl structure should be build
-    pos: RoomPosition;
+    pos: string;
 }
 
 const enum PhaseShiftStatus {

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -95,7 +95,10 @@ function handleDeadCreep(deadCreepName: string) {
         if (deadCreepMemory.role === Role.MINER && !deadCreepMemory.hasTTLReplacement) {
             Memory.rooms[deadCreepMemory.room].miningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
-        if (deadCreepMemory.role === Role.REMOTE_MINER && Memory.rooms[deadCreepMemory.room].remoteSources[deadCreepMemory.assignment]?.miner === deadCreepName) {
+        if (
+            deadCreepMemory.role === Role.REMOTE_MINER &&
+            Memory.rooms[deadCreepMemory.room].remoteSources[deadCreepMemory.assignment]?.miner === deadCreepName
+        ) {
             Memory.rooms[deadCreepMemory.room].remoteSources[deadCreepMemory.assignment].miner = AssignmentStatus.UNASSIGNED;
         }
         if (deadCreepMemory.role === Role.GATHERER) {
@@ -115,7 +118,10 @@ function handleDeadCreep(deadCreepName: string) {
         if (deadCreepMemory.role === Role.MINERAL_MINER) {
             Memory.rooms[deadCreepMemory.room].mineralMiningAssignments[deadCreepMemory.assignment] = AssignmentStatus.UNASSIGNED;
         }
-        if (deadCreepMemory.role === Role.KEEPER_EXTERMINATOR && Memory.remoteData[deadCreepMemory.assignment]?.keeperExterminator === deadCreepName) {
+        if (
+            deadCreepMemory.role === Role.KEEPER_EXTERMINATOR &&
+            Memory.remoteData[deadCreepMemory.assignment]?.keeperExterminator === deadCreepName
+        ) {
             Memory.remoteData[deadCreepMemory.assignment].keeperExterminator = AssignmentStatus.UNASSIGNED;
         }
         if (deadCreepMemory.role === Role.REMOTE_MINERAL_MINER && Memory.remoteData[deadCreepMemory.assignment]) {
@@ -256,6 +262,12 @@ function initMissingMemoryValues() {
 
     if (!Memory.debug) {
         Memory.debug = {};
+    }
+
+    if (!Memory.cpuUsage) {
+        Memory.cpuUsage = {
+            average: 0,
+        };
     }
 }
 

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -425,9 +425,9 @@ export class Pathing {
                 }
 
                 if (Memory.rooms[room.name]?.layout === RoomLayout.STAMP) {
-                    room.stamps.managers.forEach((managerStamp) => {
-                        if (!Pathing.sameCoord(managerStamp.pos, destination)) {
-                            matrix.set(managerStamp.pos.x, managerStamp.pos.y, 50);
+                    room.memory.stampLayout.managers.forEach((managerStamp) => {
+                        if (!Pathing.sameCoord(managerStamp.pos.toRoomPos(), destination)) {
+                            matrix.set(managerStamp.pos.toRoomPos().x, managerStamp.pos.toRoomPos().y, 50);
                         }
                     });
                 }

--- a/src/modules/pathing.ts
+++ b/src/modules/pathing.ts
@@ -148,12 +148,14 @@ export class Pathing {
                     //if pos on road to destination, store directions from current pos in mem
                     if (roadThruCurrentPos) {
                         pathFinder = { path: getRoadPathFromPos(roadThruCurrentPos[0], creep.pos, destination.toMemSafe()) };
+                        opts.pathColor = 'green';
                     } else {
                         let roadPositions = _.flatten(roadsToDestination.map(([key, value]) => decodeRoad(value, creep.room.name)));
                         //else find path to nearest pos on road
                         pathFinder = PathFinder.search(creep.pos, roadPositions, {
                             roomCallback: Pathing.getRoomCallback(creep.room.name, roadPositions.shift(), {}, creep.name),
                         });
+                        opts.pathColor = 'red';
                     }
                 }
             }

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -227,9 +227,8 @@ export function findRemoteMiningOptions(roomName: string, noKeeperRooms?: boolea
         if (
             [RoomMemoryStatus.VACANT, RoomMemoryStatus.RESERVED_ME, RoomMemoryStatus.RESERVED_INVADER].includes(
                 Memory.roomData[nextRoomName]?.roomStatus
-            ) && (noKeeperRooms
-                ? !isKeeperRoom(nextRoomName) && !isCenterRoom(nextRoomName)
-                : true)
+            ) &&
+            (noKeeperRooms ? !isKeeperRoom(nextRoomName) && !isCenterRoom(nextRoomName) : true)
         ) {
             safeRoomsDepthOne.push(nextRoomName);
         }
@@ -288,7 +287,7 @@ export function findRemoteMiningOptions(roomName: string, noKeeperRooms?: boolea
             return { source, stats };
         });
 
-    return openSources.filter(option => option.stats);
+    return openSources.filter((option) => option.stats);
 }
 
 export function findSuitableRemoteSource(roomName: string, noKeeperRooms: boolean = false): { source: string; stats: RemoteStats } {
@@ -307,7 +306,9 @@ export function findSuitableRemoteSource(roomName: string, noKeeperRooms: boolea
         options = options.filter((option) => option.stats?.sourceSize === 3000);
     }
 
-    options = options.filter((option) => option.stats.estimatedIncome / option.stats.gathererCount >= 500);
+    const cpuUsagePercentage = Memory.cpuUsage.average / Game.cpu.limit;
+    const minIncome = cpuUsagePercentage < 0.7 ? 500 : cpuUsagePercentage < 0.75 ? 600 : cpuUsagePercentage < 0.8 ? 700 : 1000;
+    options = options.filter((option) => option.stats.estimatedIncome / option.stats.gathererCount >= minIncome);
 
     //prefer central rooms over other rooms and prefer closer to farther
     options.sort((a, b) => b.stats.estimatedIncome - a.stats.estimatedIncome);

--- a/src/modules/remoteMining.ts
+++ b/src/modules/remoteMining.ts
@@ -307,7 +307,7 @@ export function findSuitableRemoteSource(roomName: string, noKeeperRooms: boolea
     }
 
     const cpuUsagePercentage = Memory.cpuUsage.average / Game.cpu.limit;
-    const minIncome = cpuUsagePercentage < 0.7 ? 500 : cpuUsagePercentage < 0.75 ? 600 : cpuUsagePercentage < 0.8 ? 700 : 1000;
+    const minIncome = cpuUsagePercentage < 0.75 ? 500 : cpuUsagePercentage < 0.8 ? 600 : cpuUsagePercentage < 0.85 ? 700 : 1000;
     options = options.filter((option) => option.stats.estimatedIncome / option.stats.gathererCount >= minIncome);
 
     //prefer central rooms over other rooms and prefer closer to farther

--- a/src/modules/roads.ts
+++ b/src/modules/roads.ts
@@ -50,8 +50,10 @@ export function getRoad(startPos: RoomPosition, endPos: RoomPosition, opts?: Roa
                         )
                     );
                 } else if (Memory.rooms[roomName].layout === RoomLayout.STAMP) {
-                    Object.entries(Game.rooms[roomName].stamps).forEach(([key, stampsDetails]: [string, StampDetail[]]) =>
-                        stampsDetails.forEach((detail) => matrix.set(detail.pos.x, detail.pos.y, key === 'road' || key === 'rampart' ? 1 : 255))
+                    Object.entries(Game.rooms[roomName].memory.stampLayout).forEach(([key, stampsDetails]: [string, StampDetail[]]) =>
+                        stampsDetails.forEach((detail) =>
+                            matrix.set(detail.pos.toRoomPos().x, detail.pos.toRoomPos().y, key === 'road' || key === 'rampart' ? 1 : 255)
+                        )
                     );
                 }
             }

--- a/src/modules/roomDesign.ts
+++ b/src/modules/roomDesign.ts
@@ -505,7 +505,7 @@ export function cleanRoom(room: Room) {
 }
 
 //-----------------STAMP DESIGN----------------------------------------------------
-const debug = true; // debug cpu usage
+const debug = false; // debug cpu usage
 export function findStampLocation(room: Room, storeInMemory: boolean = true) {
     logCpu('Start');
     if (Game.cpu.bucket < 200) {

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -319,7 +319,7 @@ export function driveRoom(room: Room) {
             }
         }
 
-        if (room.powerSpawn?.store.power >= 1 && room.powerSpawn?.store.energy >= 50 && room.energyStatus >= EnergyStatus.STABLE) {
+        if (room.powerSpawn?.store.power >= 1 && room.powerSpawn?.store.energy >= 50 && room.energyStatus >= EnergyStatus.SURPLUS) {
             try {
                 room.powerSpawn.processPower();
             } catch (e) {
@@ -989,7 +989,7 @@ export function destructiveReset(roomName: string) {
                 s.structureType !== STRUCTURE_SPAWN &&
                 s.structureType !== STRUCTURE_STORAGE &&
                 s.structureType !== STRUCTURE_TERMINAL &&
-                s.structureType !== STRUCTURE_EXTRACTOR
+                s.structureType !== STRUCTURE_EXTRACTOR,
         });
 
         let spawns = room.find(FIND_MY_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_SPAWN });

--- a/src/modules/visuals.ts
+++ b/src/modules/visuals.ts
@@ -58,7 +58,7 @@ function drawRoomVisuals() {
         .forEach((stampRoom) => {
             let rv = Game.rooms[stampRoom]?.visual;
             if (rv) {
-                drawLayout(rv, Game.rooms[stampRoom].stamps);
+                drawLayout(rv, Game.rooms[stampRoom].memory.stampLayout);
             }
         });
 }

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -2,7 +2,6 @@ import { addLabTask, getResourceBoostsAvailable } from '../modules/labManagement
 import { PopulationManagement } from '../modules/populationManagement';
 import { getFactoryResourcesNeeded } from '../modules/resourceManagement';
 import { findRepairTargets, getStructuresToProtect } from '../modules/roomManagement';
-import { readStampLayoutFromMemory } from '../modules/roomDesign';
 
 RoomPosition.prototype.toMemSafe = function (this: RoomPosition): string {
     return `${this.x}.${this.y}.${this.roomName}`;
@@ -96,7 +95,7 @@ Object.defineProperty(Room.prototype, 'managerLink', {
     get: function (this: Room) {
         let posToCheck = this.memory.anchorPoint?.toRoomPos() || this.memory.managerPos?.toRoomPos();
         if (this.memory.layout === RoomLayout.STAMP) {
-            posToCheck = this.stamps.link.find((linkDetail) => linkDetail.type === 'rm')?.pos;
+            posToCheck = this.memory.stampLayout.link.find((linkDetail) => linkDetail.type === 'rm')?.pos?.toRoomPos();
         } else if (this.memory.managerLink) {
             return Game.getObjectById(this.memory.managerLink);
         }
@@ -116,7 +115,7 @@ Object.defineProperty(Room.prototype, 'upgraderLink', {
     get: function (this: Room) {
         let posToCheck: RoomPosition;
         if (this.memory.layout === RoomLayout.STAMP) {
-            posToCheck = this.stamps.link.find((linkDetail) => linkDetail.type === 'controller')?.pos;
+            posToCheck = this.memory.stampLayout.link.find((linkDetail) => linkDetail.type === 'controller')?.pos?.toRoomPos();
         } else {
             posToCheck = this.memory.upgraderLinkPos?.toRoomPos();
         }
@@ -166,16 +165,6 @@ Object.defineProperty(Room.prototype, 'observer', {
 Object.defineProperty(Room.prototype, 'powerSpawn', {
     get: function (this: Room) {
         return this.find(FIND_MY_STRUCTURES).find((s) => s.structureType === STRUCTURE_POWER_SPAWN && s.isActive());
-    },
-    enumerable: false,
-    configurable: true,
-});
-
-Object.defineProperty(Room.prototype, 'stamps', {
-    get: function (this: Room) {
-        if (this.memory.layout === RoomLayout.STAMP) {
-            return readStampLayoutFromMemory(this);
-        }
     },
     enumerable: false,
     configurable: true,

--- a/src/roles/manager.ts
+++ b/src/roles/manager.ts
@@ -11,8 +11,8 @@ export class Manager extends WaveCreep {
             this.room.memory.layout === RoomLayout.STAMP ? this.memory.destination?.toRoomPos() : this.room.memory?.managerPos?.toRoomPos();
         const isCenterStampManager =
             this.room.memory.layout === RoomLayout.STAMP &&
-            this.room.stamps.managers.some(
-                (managerDetail) => managerDetail.type === 'center' && managerDetail.pos.x === managerPos.x && managerDetail.pos.y === managerPos.y
+            this.room.memory.stampLayout.managers.some(
+                (managerDetail) => managerDetail.type === 'center' && (managerDetail.pos as unknown as string) === managerPos.toMemSafe()
             );
 
         if (managerPos?.isEqualTo(this.pos) === false) {
@@ -30,7 +30,7 @@ export class Manager extends WaveCreep {
             } else if (!isCenterStampManager && this.ticksToLive > 1) {
                 this.actionTaken = true;
                 this.startNewTask();
-            } else if (isCenterStampManager && this.ticksToLive > 1) {
+            } else if (isCenterStampManager && this.ticksToLive > 1 && this.room.energyAvailable < this.room.energyCapacityAvailable) {
                 this.startCenterTask();
             }
 
@@ -63,7 +63,7 @@ export class Manager extends WaveCreep {
 
         // Send energy to the center if the center link has no energy in it
         if (!managerLink?.cooldown && storage.store.energy && this.room.memory.layout === RoomLayout.STAMP) {
-            const posToCheck = this.room.stamps.link.find((linkDetail) => linkDetail.type === 'center').pos;
+            const posToCheck = this.room.memory.stampLayout.link.find((linkDetail) => linkDetail.type === 'center').pos?.toRoomPos();
             let centerLink = posToCheck?.lookFor(LOOK_STRUCTURES).find((structure) => structure.structureType === STRUCTURE_LINK) as StructureLink;
             if (centerLink) {
                 if (!centerLink?.store.energy) {

--- a/src/virtualCreeps/waveCreep.ts
+++ b/src/virtualCreeps/waveCreep.ts
@@ -138,9 +138,9 @@ export class WaveCreep extends Creep {
                 target.recycleCreep(this);
             } else if (this.homeroom.memory.layout === RoomLayout.STAMP) {
                 this.travelTo(
-                    this.homeroom.stamps.container.find(
-                        (containerStamp) => containerStamp.type === 'center' && target.pos.isNearTo(containerStamp.pos)
-                    ).pos
+                    this.homeroom.memory.stampLayout.container
+                        .find((containerStamp) => containerStamp.type === 'center' && target.pos.isNearTo(containerStamp.pos.toRoomPos()))
+                        .pos.toRoomPos()
                 );
             } else {
                 this.travelTo(target, { range: 1 });

--- a/src/virtualCreeps/workerCreep.ts
+++ b/src/virtualCreeps/workerCreep.ts
@@ -99,11 +99,9 @@ export class WorkerCreep extends WaveCreep {
                     str.structureType === STRUCTURE_CONTAINER &&
                     str.store.energy >= this.store.getCapacity() &&
                     (this.room.memory.layout !== RoomLayout.STAMP ||
-                        !this.room.stamps.container.some(
+                        !this.room.memory.stampLayout.container.some(
                             (containerStamp) =>
-                                str.pos.x === containerStamp.pos.x &&
-                                str.pos.y === containerStamp.pos.y &&
-                                (containerStamp.type === 'center' || containerStamp.type === 'rm')
+                                str.pos.toMemSafe() === containerStamp.pos && (containerStamp.type === 'center' || containerStamp.type === 'rm')
                         ))
             );
 


### PR DESCRIPTION
Added new debugging options (logRoomCpu and logCreepCpu) which helped identify a Problem with the manager since it used way too much cpu. Turns out any call to "room.stamp" caused high cpu usage due to making a deep copy. Removed that prototype so now only direct memory access is available. Also fixed the initial Problems in roomDesign for which the deep copy was implemented (changed the .map functions so the original object stays the same).

Rooms + Creeps should now use less cpu. Also, added an average cpu value in memory which is currently only used to limit remote room claims. Depending on how much average cpu is used, the estimatedIncome will have to be higher for it to be a claimable room.