### PR TITLE
Resource revamp

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,6 @@
 declare global {
     //map of resources to rooms which need it
-    var resourceNeeds: { [resource: string]: string[] };
+    var resourceNeeds: { [resource: string]: { roomName: string; amount: number }[] };
 
     //global values shared among rooms - only one room should check constructions per tick
     var roomConstructionsChecked: boolean;

--- a/src/interfaces/creep.ts
+++ b/src/interfaces/creep.ts
@@ -3,7 +3,7 @@ interface CreepMemory {
     targetId2?: Id<Creep>;
     gatheringLabResources?: boolean;
     needsBoosted?: boolean;
-    labRequests?: LabNeed[];
+    labNeeds?: LabNeed[];
     resourceSource?: Id<Structure>;
     portalLocations?: string[];
     link?: Id<StructureLink>;

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -212,7 +212,8 @@ interface ResourceRequest {
     room: string;
     resource: ResourceConstant;
     status: ResourceRequestStatus;
-    amountNeeded: number;
+    amount: number;
+    shipments: number[];
 }
 
 const enum ResourceRequestStatus {

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -14,6 +14,8 @@ interface Memory {
     remoteSourceAssignments?: { [sourcePos: string]: RemoteAssignmentData }; //maps sources in other rooms to owned rooms mining them
     debug?: DebugSettings;
     cpuUsage: CpuUsage;
+    shipments: { [id: string]: Shipment };
+    resourceRequests: { [id: string]: ResourceRequest };
 }
 
 interface CpuUsage {
@@ -126,10 +128,21 @@ interface SquadMembers {
 }
 
 interface Shipment {
-    destinationRoom: string;
+    sender: string;
+    recipient: string;
     resource: ResourceConstant;
     amount: number;
+    status?: ShipmentStatus;
     marketOrderId?: string;
+    requestId?: string;
+}
+
+const enum ShipmentStatus {
+    FAILED = -1,
+    QUEUED,
+    PREPARING,
+    READY,
+    SHIPPED,
 }
 
 interface FactoryTask {
@@ -181,6 +194,7 @@ interface DebugSettings {
     logRoomPlacementCpu?: boolean;
     logRoomCpu?: boolean;
     logCreepCpu?: boolean;
+    logShipments?: boolean;
 }
 
 interface RemoteAssignmentData {
@@ -192,4 +206,18 @@ interface RemoteAssignmentData {
 interface EmpireResourceData {
     producers: { [mineral: string]: string[] }; //map of minerals to which rooms produce them
     inventory: { [resource: string]: number }; //total amount of each resource in empire storages and terminals
+}
+
+interface ResourceRequest {
+    room: string;
+    resource: ResourceConstant;
+    status: ResourceRequestStatus;
+    amountNeeded: number;
+}
+
+const enum ResourceRequestStatus {
+    FAILED = -1,
+    SUBMITTED,
+    ASSIGNED,
+    FULFULLED,
 }

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -195,6 +195,7 @@ interface DebugSettings {
     logRoomCpu?: boolean;
     logCreepCpu?: boolean;
     logShipments?: boolean;
+    logFactoryTasks?: boolean;
 }
 
 interface RemoteAssignmentData {

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -148,7 +148,13 @@ const enum ShipmentStatus {
 interface FactoryTask {
     product: ResourceConstant;
     amount: number;
+    needs?: FactoryNeed[];
     started?: boolean;
+}
+
+interface FactoryNeed {
+    resource: ResourceConstant;
+    amount: number;
 }
 
 const enum SquadType {

--- a/src/interfaces/memory.ts
+++ b/src/interfaces/memory.ts
@@ -188,3 +188,8 @@ interface RemoteAssignmentData {
     estimatedIncome: number;
     roadLength: number;
 }
+
+interface EmpireResourceData {
+    producers: { [mineral: string]: string[] }; //map of minerals to which rooms produce them
+    inventory: { [resource: string]: number }; //total amount of each resource in empire storages and terminals
+}

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -99,6 +99,9 @@ interface Room {
     remoteSources: string[];
     getResourceAmount(resource: ResourceConstant): number;
     getCompressedResourceAmount(resource: ResourceConstant): number;
+    addShipment(destination: string, resource: ResourceConstant, amount: number): ScreepsReturnCode;
+    addRequest(resource: ResourceConstant, amount: number): number; //returns id
+    addMarketOrder(marketId: string, amount: number);
 }
 
 interface RoomPosition {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -29,6 +29,7 @@ interface RoomMemory {
     lastRemoteSourceCheck?: number;
     threatLevel: HomeRoomThreatLevel;
     resourceRequests?: string[];
+    abandon?: boolean;
 }
 
 interface RemoteSourceData {
@@ -98,6 +99,7 @@ interface Room {
     remoteMiningRooms: string[];
     remoteSources: string[];
     getResourceAmount(resource: ResourceConstant): number;
+    getCompressedResourceAmount(resource: ResourceConstant): number;
 }
 
 interface RoomPosition {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -18,7 +18,7 @@ interface RoomMemory {
     layout?: RoomLayout;
     labTasks?: LabTask[];
     dontCheckConstructionsBefore?: number;
-    shipments?: Shipment[];
+    shipments?: number[]; //stores IDs for shipments to be referenced from Memory.shipments
     factoryTask?: FactoryTask;
     scanProgress?: string;
     towerRepairMap?: { [towerId: string]: Id<StructureRoad> }; //maps towerId to roadId
@@ -28,6 +28,7 @@ interface RoomMemory {
     remoteSources?: { [sourcePos: string]: RemoteSourceData };
     lastRemoteSourceCheck?: number;
     threatLevel: HomeRoomThreatLevel;
+    resourceRequests?: string[];
 }
 
 interface RemoteSourceData {
@@ -90,13 +91,13 @@ interface Room {
     addLabTask(opts: LabTaskOpts): ScreepsReturnCode;
     getBoostResourcesAvailable(boostTypes: BoostType[]): { [type: number]: { resource: string; amount: number }[] };
     getNextNukeProtectionTask(): Id<Structure> | Id<ConstructionSite>;
-    addShipment(destination: string, resource: ResourceConstant, amount: number, marketOrderId?: string): ScreepsReturnCode;
     addFactoryTask(product: ResourceConstant, amount: number): ScreepsReturnCode;
     factory: StructureFactory;
     observer: StructureObserver;
     powerSpawn: StructurePowerSpawn;
     remoteMiningRooms: string[];
     remoteSources: string[];
+    getResourceAmount(resource: ResourceConstant): number;
 }
 
 interface RoomPosition {

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -89,7 +89,6 @@ interface Room {
     labs: StructureLab[];
     getDefenseHitpointTarget(): number;
     addLabTask(opts: LabTaskOpts): ScreepsReturnCode;
-    getBoostResourcesAvailable(boostTypes: BoostType[]): { [type: number]: { resource: string; amount: number }[] };
     getNextNukeProtectionTask(): Id<Structure> | Id<ConstructionSite>;
     addFactoryTask(product: ResourceConstant, amount: number): ScreepsReturnCode;
     factory: StructureFactory;
@@ -97,10 +96,46 @@ interface Room {
     powerSpawn: StructurePowerSpawn;
     remoteMiningRooms: string[];
     remoteSources: string[];
+
+    /**
+     * Returns a map of each provided boost type to the number of boosts available
+     * @param boostTypes array of types to calculate
+     */
+    getBoostsAvailable(boostTypes: BoostType[]): { [type: number]: number };
+
+    /**
+     * Returns the amount of supplied resource in rooms storage or terminal not currently allocated to shipments or tasks
+     * NOTE: Don't use this function in creep methods managing factory or lab tasks - they need the actual amount of resources available
+     * @param resource the resource to query
+     */
     getResourceAmount(resource: ResourceConstant): number;
+
+    /**
+     * returns the amount of resource that exists in its compressed form in a room's storage & terminal
+     * @param resource
+     */
     getCompressedResourceAmount(resource: ResourceConstant): number;
+
+    /**
+     * Creates a Shipment in Memory.shipments from this room to another target room
+     * @param destination the target room
+     * @param resource the resource to send
+     * @param amount the amount of resource to send
+     */
     addShipment(destination: string, resource: ResourceConstant, amount: number): ScreepsReturnCode;
+
+    /**
+     * Creates a request in Memory.resourceRequests for this room
+     * @param resource the resource to request
+     * @param amount the amount of resource to request
+     */
     addRequest(resource: ResourceConstant, amount: number): number; //returns id
+
+    /**
+     * Creates a specialized shipment in Memory.shipments used to complete a market purchase
+     * @param marketId the id of the market listing to purchase
+     * @param amount the amount of resource to purchase
+     */
     addMarketOrder(marketId: string, amount: number);
 }
 

--- a/src/interfaces/room.ts
+++ b/src/interfaces/room.ts
@@ -3,7 +3,6 @@ interface RoomMemory {
     needsWallRepair?: boolean;
     upgraderLinkPos?: string;
     managerLink?: Id<Structure>;
-    labRequests?: LabNeed[];
     energyDistance?: number;
     controllerDistance?: number;
     unclaim?: boolean;
@@ -16,7 +15,7 @@ interface RoomMemory {
     mineralMiningAssignments: { [posString: string]: string };
     reservedEnergy?: number;
     layout?: RoomLayout;
-    labTasks?: LabTask[];
+    labTasks?: { [id: number]: LabTask };
     dontCheckConstructionsBefore?: number;
     shipments?: number[]; //stores IDs for shipments to be referenced from Memory.shipments
     factoryTask?: FactoryTask;

--- a/src/interfaces/structureLab.ts
+++ b/src/interfaces/structureLab.ts
@@ -1,6 +1,7 @@
 interface StructureLab {
     taskId: number;
     status: LabStatus;
+    getFreeCapacity(): number;
 }
 
 interface LabTask extends LabTaskPartial {
@@ -36,7 +37,7 @@ const enum TaskStatus {
 }
 
 const enum LabStatus {
-    AVAILABLE = 0,
+    IDLE = 0,
     IN_USE_PRIMARY,
     IN_USE_AUXILLARY,
     NEEDS_EMPTYING,

--- a/src/interfaces/structureLab.ts
+++ b/src/interfaces/structureLab.ts
@@ -1,5 +1,5 @@
 interface StructureLab {
-    taskIndex: number;
+    taskId: number;
     status: LabStatus;
 }
 
@@ -8,13 +8,13 @@ interface LabTask {
     auxillaryLabs?: Id<StructureLab>[];
     type: LabTaskType;
     status: TaskStatus;
-    reagentsNeeded?: LabNeed[];
+    needs?: LabNeed[];
     targetCreepName?: string;
 }
 
 interface LabTaskOpts {
     type: LabTaskType;
-    reagentsNeeded: LabNeed[];
+    needs: LabNeed[];
     targetCreepName?: string;
 }
 

--- a/src/modules/labManagement.ts
+++ b/src/modules/labManagement.ts
@@ -333,15 +333,15 @@ export function getReagents(compound: MineralCompoundConstant): ResourceConstant
 
 export function spawnBoostTestCreep(roomName?: string) {
     const spawnOpts: SpawnOptions = {
-        boosts: [BoostType.MOVE],
+        boosts: [BoostType.MOVE, BoostType.BUILD],
         memory: {
             role: Role.GO,
         },
     };
     const spawnAssignment: SpawnAssignment = {
-        designee: roomName ?? 'E23S43',
+        designee: roomName ?? 'E28S28',
         spawnOpts: spawnOpts,
-        body: [MOVE],
+        body: [MOVE, WORK],
     };
     Memory.spawnAssignments.push(spawnAssignment);
 }

--- a/src/modules/labManagement.ts
+++ b/src/modules/labManagement.ts
@@ -50,9 +50,11 @@ export function runLabs(room: Room) {
         }
     } else {
         const labTaskId: number = Object.entries(room.memory.labTasks).find(
-            ([taskId, task]) => task.type === LabTaskType.REACT
-        )[0] as unknown as number;
-        idleLabs.forEach((lab) => room.memory.labTasks[labTaskId].reactionLabs.push(lab.id));
+            ([taskId, task]) => task.type === LabTaskType.REACT && task.status > TaskStatus.QUEUED
+        )?.[0] as unknown as number;
+        if (labTaskId) {
+            idleLabs.forEach((lab) => room.memory.labTasks[labTaskId]?.reactionLabs?.push(lab.id));
+        }
     }
 
     //run tasks

--- a/src/modules/labManagement.ts
+++ b/src/modules/labManagement.ts
@@ -34,7 +34,7 @@ export function runLabs(room: Room) {
                 }),
             });
             if (result === OK) {
-                console.log(`${room.name} added task to create ${amountToCreate} ${resourceToMake}`);
+                console.log(`${Game.time} - ${room.name} added task to create ${amountToCreate} ${resourceToMake}`);
             }
         }
     }

--- a/src/modules/labManagement.ts
+++ b/src/modules/labManagement.ts
@@ -1,5 +1,3 @@
-import { getResourceAmount } from './resourceManagement';
-
 export function runLabs(room: Room) {
     //manage queue
     room.memory.labTasks = room.memory.labTasks.filter((task) => task.status !== TaskStatus.COMPLETE);
@@ -25,7 +23,7 @@ export function runLabs(room: Room) {
         let resourceToMake = getNextResourceToCreate(room);
         if (resourceToMake) {
             let reagents = getReagents(resourceToMake);
-            let amountToCreate = Math.min(...reagents.map((resource) => getResourceAmount(room, resource)), 3000);
+            let amountToCreate = Math.min(...reagents.map((resource) => room.getResourceAmount(resource)), 3000);
             while (amountToCreate % 5) {
                 amountToCreate--;
             }
@@ -449,7 +447,7 @@ export function getNextResourceToCreate(room: Room): MineralCompoundConstant {
 
 export function hasNecessaryReagentsForReaction(room: Room, compound: MineralCompoundConstant): boolean {
     return getReagents(compound)
-        .map((resource) => getResourceAmount(room, resource) > 450)
+        .map((resource) => room.getResourceAmount(resource) > 450)
         .reduce((hasAll, next) => hasAll && next);
 }
 

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -127,9 +127,6 @@ function handleDeadCreep(deadCreepName: string) {
         if (deadCreepMemory.role === Role.REMOTE_MINERAL_MINER && Memory.remoteData[deadCreepMemory.assignment]) {
             Memory.remoteData[deadCreepMemory.assignment].mineralMiner = AssignmentStatus.UNASSIGNED;
         }
-        if (deadCreepMemory.labRequests) {
-            Memory.rooms[deadCreepMemory.room].labRequests.unshift(...deadCreepMemory.labRequests);
-        }
     }
 
     if (deadCreepMemory.combat?.squadId) {

--- a/src/modules/memoryManagement.ts
+++ b/src/modules/memoryManagement.ts
@@ -270,6 +270,14 @@ function initMissingMemoryValues() {
             totalOverTime: 0,
         };
     }
+
+    if (!Memory.resourceRequests) {
+        Memory.resourceRequests = {};
+    }
+
+    if (!Memory.shipments) {
+        Memory.shipments = {};
+    }
 }
 
 function mangeVisionRequests() {

--- a/src/modules/operationsManagement.ts
+++ b/src/modules/operationsManagement.ts
@@ -661,7 +661,7 @@ function manageAddPowerBankOperation(op: Operation) {
                         .filter((creep) => creep.assignment === targetRoom.name && creep.role !== Role.OPERATIVE)
                         .forEach((creep) => (creep.recycle = true));
                     Object.values(Memory.squads)
-                        .filter((squad) => squad.assignment === targetRoom.name)
+                        .filter((squad) => squad.assignment === targetRoom.name && squad.members)
                         .forEach((squad) => Object.values(squad.members).forEach((creepName) => (Memory.creeps[creepName].recycle = true)));
                     op.stage = OperationStage.CLAIM;
                 }

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -1,5 +1,5 @@
 import { isCenterRoom, isKeeperRoom as isKeeperRoom } from './data';
-import { getResourceBoostsAvailable } from './labManagement';
+import { getBoostsAvailable } from './labManagement';
 import { roadIsPaved, roadIsSafe } from './roads';
 import { getStoragePos, roomNeedsCoreStructures } from './roomDesign';
 
@@ -477,9 +477,7 @@ export class PopulationManagement {
             needed.tough = 1;
         }
 
-        if (opts?.boosts) {
-            var boostMap = getResourceBoostsAvailable(room, Array.from(opts.boosts));
-        }
+        const boostMap = room.getBoostsAvailable(opts?.boosts ?? []);
 
         while (hasEnergyLeft && partsArray.length < 50 && (needed.damage > 0 || needed.heal > 0 || needed.tough > 0 || needed.move > 0)) {
             parts = parts.filter(

--- a/src/modules/populationManagement.ts
+++ b/src/modules/populationManagement.ts
@@ -765,7 +765,7 @@ export class PopulationManagement {
             return ERR_NOT_ENOUGH_ENERGY;
         }
 
-        let labTasksToAdd = [];
+        let labTasksToAdd: LabTaskOpts[] = [];
         if (spawn.room.labs.length) {
             if (opts.boosts?.length) {
                 //get total requested boosts available by type
@@ -792,7 +792,7 @@ export class PopulationManagement {
                     Object.keys(resourcesNeeded).forEach((resource) => {
                         labTasksToAdd.push({
                             type: LabTaskType.BOOST,
-                            reagentsNeeded: [{ resource: resource as ResourceConstant, amount: resourcesNeeded[resource] }],
+                            needs: [{ resource: resource as ResourceConstant, amount: resourcesNeeded[resource] }],
                             targetCreepName: name,
                         });
                     });

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -301,3 +301,38 @@ function updateBlacklistedRooms() {
     let orders = Game.market.outgoingTransactions.filter((o) => Memory.marketBlacklist.includes(o.recipient?.username));
     orders.forEach((o) => Memory.blacklistedRooms.push(o.to));
 }
+
+export function generateEmpireResourceData(): EmpireResourceData {
+    const roomsToCheck = Object.values(Game.rooms).filter((room) => room.controller?.my);
+    let data: EmpireResourceData = { producers: {}, inventory: {} };
+
+    roomsToCheck.forEach((room) => {
+        if (data.producers[room.mineral.mineralType]) {
+            data.producers[room.mineral.mineralType].push(room.name);
+        } else {
+            data.producers[room.mineral.mineralType] = [room.name];
+        }
+
+        if (room.storage) {
+            Object.keys(room.storage.store).forEach((resource) => {
+                if (data.inventory[resource]) {
+                    data.inventory[resource] += room.storage.store[resource];
+                } else {
+                    data.inventory[resource] = room.storage.store[resource];
+                }
+            });
+        }
+
+        if (room.terminal) {
+            Object.keys(room.terminal.store).forEach((resource) => {
+                if (data.inventory[resource]) {
+                    data.inventory[resource] += room.terminal.store[resource];
+                } else {
+                    data.inventory[resource] = room.terminal.store[resource];
+                }
+            });
+        }
+    });
+
+    return data;
+}

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -224,7 +224,9 @@ export function getExtraResources(room: Room): { resource: ResourceConstant; amo
     ALL_MINERALS_AND_COMPOUNDS.forEach((resource) => {
         const maxResourceAmount = resource.charAt(0) === 'X' && resource.length > 1 ? 20000 : 5000;
         const amountExtra = room.getResourceAmount(resource) + room.getCompressedResourceAmount(resource) - maxResourceAmount;
-        if (amountExtra > 0) {
+
+        //don't return very small amounts - wait for reasonable amounts to ship
+        if (amountExtra > 1000) {
             extraResources.push({ resource: resource, amount: amountExtra });
         }
     });

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -126,7 +126,7 @@ export function manageEmpireResources() {
         }
     });
 
-    //identify resource needs and distribute extra
+    //identify resource needs and distribute extra - 20k of each tier 3 boost per room, 5k of every other mineral + compound
     terminalRooms
         .filter((room) => room.energyStatus >= EnergyStatus.STABLE && room.memory.shipments.length < 3)
         .forEach((room) => {
@@ -206,7 +206,7 @@ export function getAllRoomNeeds(): { [resource: string]: { roomName: string; amo
     let needs = {};
 
     Object.values(Game.rooms)
-        .filter((room) => room.controller?.my && room.controller.level >= 6 && room.terminal)
+        .filter((room) => room.controller?.my && room.terminal?.isActive())
         .forEach((room) => {
             let roomNeeds = getRoomResourceNeeds(room);
             roomNeeds.forEach((need) => {

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -1,194 +1,109 @@
 export function manageEmpireResources() {
-    let factoryRooms = Object.values(Game.rooms).filter((room) => room.controller?.my && room.factory?.isActive());
-    factoryRooms.forEach((room) => {
-        let task = room.memory.factoryTask;
-        let factory = room.factory;
-        if (task) {
-            if (!task.started) {
-                if (factoryTaskReady(room)) {
-                    task.started = true;
-                }
-            }
-            if (task.started) {
-                let materialsUsedUp: boolean = getFactoryResourcesNeeded(task).some((need) => !factory.store[need.res]);
-                if (materialsUsedUp || factory.store[task.product] >= task.amount) {
-                    delete room.memory.factoryTask;
-                } else {
-                    if (!factory.cooldown) {
-                        let result = factory.produce(task.product as CommodityConstant);
-                        if (result !== OK) {
-                            console.log(`Removing factory task because of err: ${result}`);
-                            delete room.memory.factoryTask;
-                        }
-                    }
-                }
-            }
-        } else if (!factory.store.getUsedCapacity()) {
-            let batteryAmount = getResourceAmount(room, RESOURCE_BATTERY);
-            if (batteryAmount >= 50 && room.energyStatus < EnergyStatus.OVERFLOW && room.storage?.store.getFreeCapacity() > 100000) {
-                let result = room.addFactoryTask(RESOURCE_ENERGY, Math.min(50000, batteryAmount * 10));
-                if (result === OK) {
-                    console.log(`${room.name} added battery decompression task`);
-                }
-            }
+    //Manage shipments
+    Object.entries(Memory.shipments).forEach(([shipmentId, shipment]) => {
+        if (shipment.status === ShipmentStatus.SHIPPED) {
+            delete Memory.shipments[shipmentId];
+        } else if (shipment.status === ShipmentStatus.FAILED) {
+            console.log(`Shipment failed unexpectedly: ${shipment.recipient} - ${shipment.resource}`);
+            delete Memory.shipments[shipmentId];
         }
     });
 
     let terminalRooms = Object.values(Game.rooms).filter((room) => room.controller?.my && room.terminal?.isActive());
-    let roomsInNeed = terminalRooms.filter((room) => room.energyStatus < EnergyStatus.STABLE).sort((a, b) => a.energyStatus - b.energyStatus);
-    let roomsInProgress = terminalRooms.filter((room) => room.controller.level < 8 && room.energyStatus < EnergyStatus.SURPLUS);
 
-    terminalRooms
-        .filter((room) => !room.terminal.cooldown)
-        .forEach((room) => {
-            if (!room.memory.shipments?.length) {
-                if (hasExtraEnergy(room) && room.terminal.store.energy >= 50000) {
-                    if (roomsInNeed.length) {
-                        let recipientName = findClosestRecipient(room, roomsInNeed);
-                        let amountToSend = calculateEnergyToSend(room.name, recipientName);
-                        let result = room.terminal.send(RESOURCE_ENERGY, amountToSend, recipientName);
-                        if (result === OK) {
-                            console.log(
-                                `${room.name} sent ${amountToSend} energy to ${recipientName}: Cost: ${Game.market.calcTransactionCost(
-                                    amountToSend,
-                                    room.name,
-                                    recipientName
-                                )}`
-                            );
-                            return;
-                        } else {
-                            console.log(
-                                `${room.name} was unable to send energy to ${recipientName}: ${result} Cost: ${Game.market.calcTransactionCost(
-                                    amountToSend,
-                                    room.name,
-                                    recipientName
-                                )}`
-                            );
-                        }
-                    } else if (roomsInProgress.length && hasTooMuchEnergy(room)) {
-                        let recipientName = findClosestRecipient(room, roomsInProgress);
-                        let amountToSend = calculateEnergyToSend(room.name, recipientName);
-                        let result = room.terminal.send(RESOURCE_ENERGY, amountToSend, recipientName);
-                        if (result === OK) {
-                            console.log(
-                                `${room.name} sent ${amountToSend} energy to ${recipientName}: Cost: ${Game.market.calcTransactionCost(
-                                    amountToSend,
-                                    room.name,
-                                    recipientName
-                                )}`
-                            );
-                            return;
-                        } else {
-                            console.log(
-                                `${room.name} was unable to send energy to ${recipientName}: ${result} Cost: ${Game.market.calcTransactionCost(
-                                    amountToSend,
-                                    room.name,
-                                    recipientName
-                                )}`
-                            );
-                        }
-                    }
+    //distribute energy throughout empire
+    if (Game.time % 25 === 0) {
+        const roomEnergyMap = terminalRooms.map((room) => ({
+            energyTier: Math.floor(room.getResourceAmount(RESOURCE_ENERGY) / 100000),
+            roomName: room.name,
+        }));
+        let energyShipments: { sender: string; recipient: string; amount: number }[] = [];
+
+        roomEnergyMap
+            .filter((e) => e.energyTier > 2 && !Memory.rooms[e.roomName].shipments.some((id) => Memory.shipments[id]?.resource === RESOURCE_ENERGY))
+            .forEach((sender) => {
+                let recipient = roomEnergyMap.find(
+                    (otherEntry) => sender.energyTier > 1 + otherEntry.energyTier && !energyShipments.some((s) => s.recipient === otherEntry.roomName)
+                )?.roomName;
+                if (recipient) {
+                    let amountToSend = calculateEnergyToSend(sender.roomName, recipient);
+                    energyShipments.push({ sender: sender.roomName, recipient: recipient, amount: amountToSend });
                 }
+            });
 
-                let extraResources = getExtraResources(room);
-                if (extraResources.length && room.energyStatus >= EnergyStatus.STABLE) {
-                    let sent = false;
-                    extraResources.forEach((resource) => {
-                        let roomsInNeed = global.resourceNeeds[resource];
-                        let excessAmount = getResourceAmount(room, resource) - 10000;
-                        if (roomsInNeed?.length && !sent) {
-                            let recipient = findClosestRecipient(
-                                room,
-                                roomsInNeed.map((roomName) => Game.rooms[roomName])
-                            );
-                            let amountToSend = Math.max(2500, 5000 - getResourceAmount(Game.rooms[recipient], resource));
-                            let result = room.terminal.send(resource, amountToSend, recipient);
-                            if (result === OK) {
-                                console.log(
-                                    `${room.name} sent ${amountToSend} ${resource} to ${recipient}: Cost: ${Game.market.calcTransactionCost(
-                                        amountToSend,
-                                        room.name,
-                                        recipient
-                                    )}`
-                                );
-                                sent = true;
-                                return;
-                            } else {
-                                console.log(
-                                    `${room.name} was unable to send ${resource} to ${recipient}: ${result} Cost: ${Game.market.calcTransactionCost(
-                                        amountToSend,
-                                        room.name,
-                                        recipient
-                                    )}`
-                                );
-                            }
-                        } else if (!sent && Game.time % 50 === 0) {
-                            if (!global.qualifyingMarketOrders) {
-                                updateBlacklistedRooms();
-                                getQualifyingMarketOrders();
-                            }
-                            let buyRequest = Game.market.getOrderById(global.qualifyingMarketOrders[resource]);
-                            if (buyRequest?.amount) {
-                                let amountToSell = Math.min(excessAmount, buyRequest.amount, 75000);
-                                let result = room.addShipment(buyRequest.roomName, resource, amountToSell, buyRequest.id);
-                                if (result === OK) {
-                                    sent = true;
-                                    console.log(
-                                        `${room.name} added shipment of ${amountToSell} ${buyRequest.resourceType} to complete market order ${buyRequest.id}`
-                                    );
-                                    global.qualifyingMarketOrders[resource] = undefined;
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-
-            let readyShipmentIndex = room.memory.shipments?.findIndex((shipment) => shipmentReady(room.terminal, shipment));
-
-            if (readyShipmentIndex > -1) {
-                let shipment = room.memory.shipments[readyShipmentIndex];
-                let result: ScreepsReturnCode;
-                if (shipment.marketOrderId) {
-                    result = Game.market.deal(shipment.marketOrderId, shipment.amount, room.name);
-                    if (result === OK) {
-                        room.memory.shipments.splice(readyShipmentIndex, 1);
-                        console.log(
-                            `${room.name} completed sale of ${shipment.amount} ${shipment.resource} for ${
-                                shipment.amount * Game.market.getOrderById(shipment.marketOrderId).price
-                            } credits`
-                        );
-                    } else {
-                        console.log(`${room.name} was unable to complete sale of ${shipment.resource}: ${result}`);
-                        room.memory.shipments.splice(readyShipmentIndex, 1);
-                    }
-                } else {
-                    result = room.terminal.send(shipment.resource, shipment.amount, shipment.destinationRoom);
-                    if (result === OK) {
-                        room.memory.shipments.splice(readyShipmentIndex, 1);
-                        console.log(`${room.name} sent ${shipment.amount} ${shipment.resource} to ${shipment.destinationRoom}`);
-                    } else {
-                        console.log(`${room.name} was unable to send ${shipment.resource}: ${result}`);
-                    }
-                }
-            }
+        energyShipments.forEach((shipmentToCreate) => {
+            const shipment: Shipment = {
+                sender: shipmentToCreate.sender,
+                resource: RESOURCE_ENERGY,
+                recipient: shipmentToCreate.recipient,
+                amount: shipmentToCreate.amount,
+            };
+            addShipment(shipment);
         });
+    }
+
+    //manage resource requests - if rooms have this resource, they should send it regardless of how much they have
+    Object.entries(Memory.resourceRequests).forEach(([requestId, request]) => {
+        if (request.status === ResourceRequestStatus.FULFULLED) {
+            delete Memory.resourceRequests[requestId];
+        } else if (request.status === ResourceRequestStatus.FAILED) {
+            console.log(`Resource request failed unexpectedly: ${request.room} - ${request.resource}`);
+            delete Memory.resourceRequests[requestId];
+        } else {
+            const supplier = terminalRooms.find((room) => room.getResourceAmount(request.resource) >= request.amountNeeded);
+            if (supplier) {
+                const shipment: Shipment = {
+                    sender: supplier.name,
+                    recipient: request.room,
+                    amount: request.amountNeeded,
+                    resource: request.resource,
+                    requestId: requestId,
+                };
+
+                addShipment(shipment);
+                Memory.resourceRequests[requestId].status = ResourceRequestStatus.ASSIGNED;
+            }
+        }
+    });
+
+    // //identify resource needs and distribute extra
+    // terminalRooms
+    //     .filter((room) => room.energyStatus >= EnergyStatus.STABLE && room.memory.shipments.length < 3)
+    //     .forEach((room) => {
+    //         const extraResources = getExtraResources(room);
+    //         extraResources.forEach((extraResource) => {
+    //             const roomsNeedingResource = global.resourceNeeds[extraResource.resource]?.filter(
+    //                 (need) =>
+    //                     !Object.values(Memory.shipments).some(
+    //                         (shipment) => shipment.resource === extraResource.resource && shipment.recipient === need.roomName
+    //                     )
+    //             );
+    //             const excessAmount = extraResource.amountExtra;
+
+    //             if (roomsNeedingResource?.length) {
+    //                 const roomToSupply = findClosestRecipient(room, roomsNeedingResource);
+    //                 if (roomToSupply) {
+    //                     const amountToSend = Math.min(excessAmount, roomToSupply.amountNeeded);
+    //                     const shipment: Shipment = {
+    //                         sender: room.name,
+    //                         resource: extraResource.resource,
+    //                         amount: amountToSend,
+    //                         recipient: roomToSupply.roomName,
+    //                     };
+
+    //                     addShipment(shipment);
+    //                 }
+    //             }
+    //         });
+    //     });
 }
 
-function hasExtraEnergy(room: Room): boolean {
-    return room.energyStatus > EnergyStatus.STABLE;
-}
-
-function hasTooMuchEnergy(room: Room): boolean {
-    return room.energyStatus === EnergyStatus.OVERFLOW || (room.controller.level === 8 && room.energyStatus > EnergyStatus.STABLE);
-}
-
-function findClosestRecipient(sender: Room, recipients: Room[]): string {
-    let distanceMap = recipients.map((room) => {
-        return { name: room.name, distance: Game.map.getRoomLinearDistance(sender.name, room.name) };
+function findClosestRecipient(sender: Room, recipients: any[]): { roomName: string; amountNeeded: number } {
+    let distanceMap = recipients.map((need) => {
+        return { name: need.roomName, amount: need.amountNeeded, distance: Game.map.getRoomLinearDistance(sender.name, need.roomName) };
     });
     let closest = distanceMap.reduce((closestSoFar, next) => (closestSoFar.distance < next.distance ? closestSoFar : next));
-    return closest.name;
+    return { roomName: closest.name, amountNeeded: closest.amount };
 }
 
 function calculateEnergyToSend(senderName: string, recipientName: string) {
@@ -202,23 +117,20 @@ function calculateEnergyToSend(senderName: string, recipientName: string) {
     return 10000 * multiple;
 }
 
-function getRoomResourceNeeds(room: Room): ResourceConstant[] {
+export function getRoomResourceNeeds(room: Room): { resource: ResourceConstant; amount: number }[] {
     let needs = [];
     const ALL_MINERALS_AND_COMPOUNDS = [...Object.keys(MINERAL_MIN_AMOUNT), ...Object.keys(REACTION_TIME)] as ResourceConstant[];
     ALL_MINERALS_AND_COMPOUNDS.forEach((resource) => {
-        if (getResourceAmount(room, resource) < 5000) {
-            needs.push(resource);
+        let need = (resource.charAt(0) === 'X' && resource.length > 1 ? 20000 : 5000) - room.getResourceAmount(resource);
+        if (need > 0) {
+            needs.push({ resource: resource, amount: need });
         }
     });
 
     return needs;
 }
 
-export function getResourceAmount(room: Room, resource: ResourceConstant): number {
-    return (room.storage?.store[resource] ?? 0) + (room.terminal?.store[resource] ?? 0);
-}
-
-export function getAllRoomNeeds(): { [resource: string]: string[] } {
+export function getAllRoomNeeds(): { [resource: string]: { roomName: string; amount: number }[] } {
     let needs = {};
 
     Object.values(Game.rooms)
@@ -226,38 +138,32 @@ export function getAllRoomNeeds(): { [resource: string]: string[] } {
         .forEach((room) => {
             let roomNeeds = getRoomResourceNeeds(room);
             roomNeeds.forEach((need) => {
-                needs[need] = [...(needs[need] ?? []), room.name];
+                needs[need.resource] = [...(needs[need.resource] ?? []), { roomName: room.name, amount: need.amount }];
             });
         });
 
     return needs;
 }
 
-export function getExtraResources(room: Room): ResourceConstant[] {
-    let extraResources = [];
+export function getExtraResources(room: Room): { resource: ResourceConstant; amount: number }[] {
+    let extraResources: { resource: ResourceConstant; amount: number }[] = [];
 
     const ALL_MINERALS_AND_COMPOUNDS = [...Object.keys(MINERAL_MIN_AMOUNT), ...Object.keys(REACTION_TIME)] as ResourceConstant[];
     ALL_MINERALS_AND_COMPOUNDS.forEach((resource) => {
-        let maxResourceAmount = 10000;
-        // Increase Defensive Resource Amount
-        if (resource === RESOURCE_CATALYZED_UTRIUM_ACID) {
-            maxResourceAmount = 20000;
-        }
-        if (
-            resource !== RESOURCE_CATALYZED_UTRIUM_ACID &&
-            getResourceAmount(room, resource) > maxResourceAmount &&
-            room.terminal.store[resource] >= 5000
-        ) {
-            extraResources.push(resource);
+        const maxResourceAmount = resource.charAt(0) === 'X' && resource.length > 1 ? 20000 : 5000;
+        const amountExtra = room.getResourceAmount(resource) - maxResourceAmount;
+        if (amountExtra > 0) {
+            extraResources.push({ resource: resource, amount: amountExtra });
         }
     });
 
     return extraResources;
 }
 
-export function shipmentReady(terminal: StructureTerminal, shipment: Shipment): boolean {
+export function shipmentReady(terminal: StructureTerminal, shipmentId: number): boolean {
+    const shipment = Memory.shipments[shipmentId];
     let energyNeeded =
-        Game.market.calcTransactionCost(shipment.amount, terminal.room.name, shipment.destinationRoom) +
+        Game.market.calcTransactionCost(shipment.amount, terminal.room.name, shipment.recipient) +
         (shipment.resource === RESOURCE_ENERGY ? shipment.amount : 0);
 
     return terminal.store[shipment.resource] >= shipment.amount && terminal.store.energy >= energyNeeded;
@@ -274,27 +180,6 @@ function getQualifyingMarketOrders() {
             global.qualifyingMarketOrders[res] = orderId;
         }
     });
-}
-
-export function factoryTaskReady(room: Room): boolean {
-    if (room.memory.factoryTask) {
-        let neededResources = getFactoryResourcesNeeded(room.memory.factoryTask);
-        return neededResources.every((need) => room.factory.store[need.res] >= need.amount);
-    }
-}
-
-export function getFactoryResourcesNeeded(task: FactoryTask): { res: ResourceConstant; amount: number }[] {
-    let needs: { res: ResourceConstant; amount: number }[] = [];
-    let commodityEntry: { amount: number; cooldown: number; components: { [resource: string]: number } } = COMMODITIES[task.product];
-    let amountProduced = commodityEntry.amount;
-    let componentResources = Object.keys(commodityEntry.components);
-    let componentsAmounts = commodityEntry.components;
-
-    needs = componentResources.map((resource) => {
-        return { res: resource as ResourceConstant, amount: componentsAmounts[resource] * Math.floor(task.amount / amountProduced) };
-    });
-
-    return needs;
 }
 
 function updateBlacklistedRooms() {
@@ -335,4 +220,20 @@ export function generateEmpireResourceData(): EmpireResourceData {
     });
 
     return data;
+}
+
+// adds shipment to Memory.shipments & returns reference id
+export function addShipment(shipment: Shipment): ScreepsReturnCode {
+    let nextId = 1;
+    while (Memory.shipments[nextId]) {
+        nextId++;
+    }
+
+    shipment.status = ShipmentStatus.QUEUED;
+
+    Memory.shipments[nextId] = shipment;
+    Memory.rooms[shipment.sender].shipments.push(nextId);
+    if (Memory.debug.logShipments)
+        console.log(`${Game.time} - Shipment added to ${shipment.sender} -> ${shipment.amount} energy to ${shipment.recipient}`);
+    return OK;
 }

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -21,27 +21,28 @@ export function manageEmpireResources() {
 
         roomsWithExtraEnergy.forEach((sender) => {
             let recipient = roomEnergyMap.find(
-                (otherRoom) => sender.energy > 150000 + otherRoom.energy && !shipments.some((s) => s.recipient === otherRoom.roomName)
+                (otherRoom) =>
+                    sender.energy > 150000 + otherRoom.energy + 10 * otherRoom.batteries && !shipments.some((s) => s.recipient === otherRoom.roomName)
             );
             if (recipient) {
-                // //if there are batteries to send, use those instead
-                // if(sender.batteries && recipient.hasFactory){
-                //     const shipment: Shipment = {
-                //         sender: sender.roomName,
-                //         recipient: recipient.roomName,
-                //         resource: RESOURCE_BATTERY,
-                //         amount: Math.min(sender.batteries, 5000)
-                //     };
-                //     shipments.push(shipment);
-                // } else {
-                const shipment: Shipment = {
-                    sender: sender.roomName,
-                    recipient: recipient.roomName,
-                    resource: RESOURCE_ENERGY,
-                    amount: calculateEnergyToSend(sender.roomName, recipient.roomName),
-                };
-                shipments.push(shipment);
-                // }
+                //if there are batteries to send, use those instead
+                if (sender.batteries && recipient.hasFactory) {
+                    const shipment: Shipment = {
+                        sender: sender.roomName,
+                        recipient: recipient.roomName,
+                        resource: RESOURCE_BATTERY,
+                        amount: Math.min(sender.batteries, 5000),
+                    };
+                    shipments.push(shipment);
+                } else {
+                    const shipment: Shipment = {
+                        sender: sender.roomName,
+                        recipient: recipient.roomName,
+                        resource: RESOURCE_ENERGY,
+                        amount: calculateEnergyToSend(sender.roomName, recipient.roomName),
+                    };
+                    shipments.push(shipment);
+                }
             }
         });
 

--- a/src/modules/resourceManagement.ts
+++ b/src/modules/resourceManagement.ts
@@ -1,16 +1,4 @@
 export function manageEmpireResources() {
-    //Manage shipments not associated to requests - those will be handled with requests
-    Object.entries(Memory.shipments)
-        .filter(([shipmentId, shipment]) => !shipment.requestId)
-        .forEach(([shipmentId, shipment]) => {
-            if (shipment.status === ShipmentStatus.SHIPPED && !shipment.requestId) {
-                delete Memory.shipments[shipmentId];
-            } else if (shipment.status === ShipmentStatus.FAILED) {
-                console.log(`${Game.time} - Shipment failed unexpectedly: ${shipment.recipient} - ${shipment.resource}`);
-                delete Memory.shipments[shipmentId];
-            }
-        });
-
     let terminalRooms = Object.values(Game.rooms).filter((room) => room.controller?.my && room.terminal?.isActive() && !room.memory.abandon);
 
     //distribute energy throughout empire
@@ -160,6 +148,18 @@ export function manageEmpireResources() {
                     }
                 }
             });
+        });
+
+    //Manage shipments not associated to requests - those are handled with requests
+    Object.entries(Memory.shipments)
+        .filter(([shipmentId, shipment]) => !shipment.requestId)
+        .forEach(([shipmentId, shipment]) => {
+            if (shipment.status === ShipmentStatus.SHIPPED && !shipment.requestId) {
+                delete Memory.shipments[shipmentId];
+            } else if (shipment.status === ShipmentStatus.FAILED) {
+                console.log(`${Game.time} - Shipment failed unexpectedly: ${shipment.recipient} - ${shipment.resource}`);
+                delete Memory.shipments[shipmentId];
+            }
         });
 }
 

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -1205,12 +1205,12 @@ function runShipments(room: Room) {
                                 );
                             Memory.shipments[shipmentId].status = ShipmentStatus.SHIPPED;
                             shipmentSentThisTick = true;
+                        } else {
+                            console.log(
+                                `${Game.time} - Shipment FAILED: ${shipment.sender} -> ${shipment.amount} ${shipment.resource} to ${shipment.recipient} - no recipient terminal`
+                            );
+                            Memory.shipments[shipmentId].status = ShipmentStatus.FAILED;
                         }
-                    } else if (!Game.rooms[shipment.recipient]?.terminal) {
-                        console.log(
-                            `${Game.time} - Shipment FAILED: ${shipment.sender} -> ${shipment.amount} ${shipment.resource} to ${shipment.recipient} - no recipient terminal`
-                        );
-                        Memory.shipments[shipmentId].status = ShipmentStatus.FAILED;
                     }
                     break;
             }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -455,7 +455,7 @@ function runHomeSecurity(homeRoom: Room): boolean {
         return false;
     }
 
-    if (hostileCreepData.creeps.length >= 2) {
+    if (hostileCreepData.creeps.length >= 1) {
         // Spawn multiple rampartProtectors based on the number of enemy hostiles
         const currentNumProtectors = PopulationManagement.currentNumRampartProtectors(homeRoom.name);
         if (

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -669,7 +669,7 @@ function runSpawning(room: Room) {
         }
     }
 
-    if (PopulationManagement.needsMineralMiner(room)) {
+    if (PopulationManagement.needsMineralMiner(room) && !roomUnderAttack) {
         let spawn = availableSpawns.pop();
         spawn?.spawnMineralMiner();
     }
@@ -1076,6 +1076,32 @@ function runFactory(room: Room) {
                         delete room.memory.factoryTask;
                     }
                 }
+            }
+        }
+    } else {
+        const energyStatus = room.energyStatus;
+        const batteryCount = room.getResourceAmount(RESOURCE_BATTERY);
+        if (room.getResourceAmount(RESOURCE_ENERGY) > 375000 && batteryCount < 100000) {
+            let newTask: FactoryTask = {
+                product: RESOURCE_BATTERY,
+                amount: 1500,
+            };
+
+            room.memory.factoryTask = newTask;
+            if (Memory.debug.logFactoryTasks) {
+                console.log(`${room.name} added task -> ${newTask.amount} ${newTask.product}`);
+            }
+        } else if ((energyStatus <= EnergyStatus.SURPLUS && batteryCount > 100000) || (energyStatus <= EnergyStatus.STABLE && batteryCount >= 50)) {
+            let setsOfFifty = Math.floor(batteryCount / 50);
+            let energyToCreate = 10 * 50 * Math.min(40, setsOfFifty);
+            let newTask: FactoryTask = {
+                product: RESOURCE_ENERGY,
+                amount: energyToCreate,
+            };
+
+            room.memory.factoryTask = newTask;
+            if (Memory.debug.logFactoryTasks) {
+                console.log(`${room.name} added task -> ${newTask.amount} ${newTask.product}`);
             }
         }
     }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -1167,7 +1167,7 @@ function runShipments(room: Room) {
                 }
             case ShipmentStatus.READY:
                 const destinationReady = Game.rooms[shipment.recipient]?.controller.my
-                    ? Game.rooms[shipment.recipient].terminal.store.getFreeCapacity() >= shipment.amount
+                    ? Game.rooms[shipment.recipient].terminal?.store.getFreeCapacity() >= shipment.amount
                     : true;
                 if (!shipmentSentThisTick && room.terminal.cooldown === 0 && destinationReady) {
                     const result = room.terminal.send(shipment.resource, shipment.amount, shipment.recipient);
@@ -1179,6 +1179,11 @@ function runShipments(room: Room) {
                         Memory.shipments[shipmentId].status = ShipmentStatus.SHIPPED;
                         shipmentSentThisTick = true;
                     }
+                } else if (!Game.rooms[shipment.recipient]?.terminal) {
+                    console.log(
+                        `${Game.time} - Shipment FAILED: ${shipment.sender} -> ${shipment.amount} ${shipment.resource} to ${shipment.recipient} - no recipient terminal`
+                    );
+                    Memory.shipments[shipmentId].status = ShipmentStatus.FAILED;
                 }
                 break;
         }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -1123,7 +1123,7 @@ function runShipments(room: Room) {
                 if (canSupportShipment) {
                     if (Memory.debug.logShipments)
                         console.log(
-                            `Room preparing shipment: ${shipment.sender} => ${shipment.amount} ${shipment.resource} to ${shipment.recipient}`
+                            `${Game.time} - Room preparing shipment: ${shipment.sender} -> ${shipment.amount} ${shipment.resource} to ${shipment.recipient}`
                         );
                     Memory.shipments[shipmentId].status = ShipmentStatus.PREPARING;
                 } else {
@@ -1132,7 +1132,9 @@ function runShipments(room: Room) {
             case ShipmentStatus.PREPARING:
                 if (shipmentReady(room.terminal, shipmentId)) {
                     if (Memory.debug.logShipments)
-                        console.log(`Shipment ready: ${shipment.sender} => ${shipment.amount} ${shipment.resource} to  ${shipment.recipient}`);
+                        console.log(
+                            `${Game.time} - Shipment ready: ${shipment.sender} -> ${shipment.amount} ${shipment.resource} to  ${shipment.recipient}`
+                        );
                     Memory.shipments[shipmentId].status = ShipmentStatus.READY;
                 } else {
                     break;
@@ -1145,7 +1147,9 @@ function runShipments(room: Room) {
                     const result = room.terminal.send(shipment.resource, shipment.amount, shipment.recipient);
                     if (result === OK) {
                         if (Memory.debug.logShipments)
-                            console.log(`Shipment sent: ${shipment.sender} => ${shipment.amount} ${shipment.resource} to ${shipment.recipient}`);
+                            console.log(
+                                `${Game.time} - Shipment sent: ${shipment.sender} -> ${shipment.amount} ${shipment.resource} to ${shipment.recipient}`
+                            );
                         Memory.shipments[shipmentId].status = ShipmentStatus.SHIPPED;
                         shipmentSentThisTick = true;
                     }

--- a/src/modules/roomManagement.ts
+++ b/src/modules/roomManagement.ts
@@ -917,10 +917,6 @@ export function canSupportRemoteRoom(room: Room) {
 }
 
 function initMissingMemoryValues(room: Room) {
-    if (!room.memory.labRequests) {
-        room.memory.labRequests = [];
-    }
-
     if (!room.memory.gates) {
         room.memory.gates = [];
     }
@@ -1021,7 +1017,6 @@ export function destructiveReset(roomName: string) {
         creeps.forEach((c) => {
             if (Memory.creeps[c].role === Role.DISTRIBUTOR || Memory.creeps[c].role === Role.WORKER) {
                 delete Memory.creeps[c].targetId;
-                delete Memory.creeps[c].labRequests;
                 delete Memory.creeps[c].destination;
                 delete Memory.creeps[c].energySource;
             } else {

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -261,7 +261,7 @@ Room.prototype.addFactoryTask = function (this: Room, product: ResourceConstant,
         } else {
             let resourcesNeeded = getFactoryResourcesNeeded({ product: product, amount: amount });
             let roomHasEnoughMaterials = resourcesNeeded.reduce(
-                (needsMet, nextNeed) => needsMet && nextNeed.amount < this.getResourceAmount(nextNeed.resource),
+                (needsMet, nextNeed) => needsMet && nextNeed.amount <= this.getResourceAmount(nextNeed.resource),
                 true
             );
             if (!roomHasEnoughMaterials) {

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -1,5 +1,6 @@
 import { addLabTask, getResourceBoostsAvailable } from '../modules/labManagement';
 import { PopulationManagement } from '../modules/populationManagement';
+import { addMarketOrder, addResourceRequest, addShipment } from '../modules/resourceManagement';
 import { getFactoryResourcesNeeded } from '../modules/roomManagement';
 import { findRepairTargets, getStructuresToProtect } from '../modules/roomManagement';
 
@@ -282,4 +283,22 @@ Room.prototype.addFactoryTask = function (this: Room, product: ResourceConstant,
             return ERR_FULL;
         }
     }
+};
+
+Room.prototype.addRequest = function (this: Room, resource: ResourceConstant, amount: number): number {
+    return addResourceRequest(this.name, resource, amount);
+};
+
+Room.prototype.addShipment = function (this: Room, destination: string, resource: ResourceConstant, amount: number): ScreepsReturnCode {
+    const shipment: Shipment = {
+        sender: this.name,
+        recipient: destination,
+        resource: resource,
+        amount: amount,
+    };
+    return addShipment(shipment);
+};
+
+Room.prototype.addMarketOrder = function (this: Room, marketId: string, amount: number) {
+    return addMarketOrder(this.name, marketId, amount);
 };

--- a/src/prototypes/structureLab.ts
+++ b/src/prototypes/structureLab.ts
@@ -1,7 +1,8 @@
-Object.defineProperty(StructureLab.prototype, 'taskIndex', {
+Object.defineProperty(StructureLab.prototype, 'taskId', {
     get: function (this: StructureLab) {
-        let index = this.room.memory.labTasks.findIndex((task) => task.reactionLabs?.includes(this.id) || task.auxillaryLabs?.includes(this.id));
-        return index > -1 ? index : undefined;
+        return Object.entries(this.room.memory.labTasks).find(
+            (task) => task[1].reactionLabs?.includes(this.id) || task[1].auxillaryLabs?.includes(this.id)
+        )?.[0];
     },
     enumerable: false,
     configurable: true,
@@ -9,11 +10,11 @@ Object.defineProperty(StructureLab.prototype, 'taskIndex', {
 
 Object.defineProperty(StructureLab.prototype, 'status', {
     get: function (this: StructureLab) {
-        return !this.room.memory.labTasks[this.taskIndex]
+        return !this.room.memory.labTasks[this.taskId]
             ? !this.mineralType
                 ? LabStatus.AVAILABLE
                 : LabStatus.NEEDS_EMPTYING
-            : this.room.memory.labTasks[this.taskIndex].reactionLabs?.includes(this.id)
+            : this.room.memory.labTasks[this.taskId].reactionLabs?.includes(this.id)
             ? LabStatus.IN_USE_PRIMARY
             : LabStatus.IN_USE_AUXILLARY;
     },

--- a/src/prototypes/structureLab.ts
+++ b/src/prototypes/structureLab.ts
@@ -28,5 +28,5 @@ Object.defineProperty(StructureLab.prototype, 'status', {
  */
 StructureLab.prototype.getFreeCapacity = function (this: StructureLab) {
     const task = this.room.memory.labTasks[this.taskId];
-    return (this.mineralType ? this.store.getFreeCapacity(this.mineralType) : 3000) - (task?.needs.find((need) => need.lab === this.id).amount ?? 0);
+    return (this.mineralType ? this.store.getFreeCapacity(this.mineralType) : 3000) - (task?.needs.find((need) => need.lab === this.id)?.amount ?? 0);
 };

--- a/src/roles/distributor.ts
+++ b/src/roles/distributor.ts
@@ -4,7 +4,8 @@ export class Distributor extends TransportCreep {
     protected findTarget() {
         let target: any;
 
-        if (!target && this.homeroom.memory.labRequests?.length) {
+        const outstandingLabNeeds: boolean = Object.values(this.homeroom.memory.labTasks).some((task) => task.needs.some((need) => need.amount > 0));
+        if (!target && outstandingLabNeeds) {
             if (this.store.getUsedCapacity() && this.homeroom.storage) {
                 target = this.homeroom.storage.id;
             } else {

--- a/src/roles/distributor.ts
+++ b/src/roles/distributor.ts
@@ -4,7 +4,9 @@ export class Distributor extends TransportCreep {
     protected findTarget() {
         let target: any;
 
-        const outstandingLabNeeds: boolean = Object.values(this.homeroom.memory.labTasks).some((task) => task.needs.some((need) => need.amount > 0));
+        const outstandingLabNeeds: boolean = Object.values(this.homeroom.memory.labTasks).some(
+            (task) => [TaskStatus.PREPARING, TaskStatus.ACTIVE].includes(task.status) && task.needs.some((need) => need.amount > 0)
+        );
         if (!target && outstandingLabNeeds) {
             if (this.store.getUsedCapacity() && this.homeroom.storage) {
                 target = this.homeroom.storage.id;

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -55,6 +55,7 @@ export class TransportCreep extends WaveCreep {
         let target: any = Game.getObjectById(this.memory.targetId);
         if (target instanceof Resource) {
             this.runPickupJob(target);
+            return false;
         } else if (
             target instanceof StructureContainer &&
             this.homeroom.memory.layout === RoomLayout.STAMP &&
@@ -63,6 +64,7 @@ export class TransportCreep extends WaveCreep {
             )
         ) {
             this.runRefillJob(target);
+            return false;
         } else if (
             target instanceof Tombstone ||
             target instanceof Ruin ||
@@ -70,6 +72,7 @@ export class TransportCreep extends WaveCreep {
             target?.status === LabStatus.NEEDS_EMPTYING
         ) {
             this.runCollectionJob(target);
+            return false;
         } else if (
             target instanceof StructureSpawn ||
             target instanceof StructureExtension ||
@@ -77,10 +80,13 @@ export class TransportCreep extends WaveCreep {
             target instanceof StructureLab
         ) {
             this.runRefillJob(target);
+            return false;
         } else if (target instanceof StructureStorage) {
             this.storeCargo();
+            return false;
         } else if (target instanceof StructurePowerSpawn) {
             this.runRefillPowerSpawnJob(target);
+            return false;
         }
 
         return true;

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -642,6 +642,14 @@ export class TransportCreep extends WaveCreep {
                 }
             }
         } else {
+            //check in-memory need validity
+            if (this.memory.labNeeds[0]?.lab) {
+                const labToCheck = Game.getObjectById(this.memory.labNeeds[0].lab);
+                if (!labToCheck.taskId || labToCheck.status === LabStatus.NEEDS_EMPTYING) {
+                    this.memory.labNeeds.shift();
+                }
+            }
+
             if (this.store.getUsedCapacity(this.memory.labNeeds[0]?.resource)) {
                 const nextNeed = this.memory.labNeeds[0];
                 const targetLab: StructureLab = Game.getObjectById(nextNeed.lab);
@@ -651,11 +659,8 @@ export class TransportCreep extends WaveCreep {
                     const amountToTransfer = Math.min(nextNeed.amount, this.store[nextNeed.resource]);
                     let result = this.transfer(targetLab, nextNeed.resource, Math.min(nextNeed.amount, this.store[nextNeed.resource]));
                     if (result === OK) {
-                        console.log(`${Game.time} - Amount transferred = ${amountToTransfer}`);
                         const labTaskId = targetLab.taskId;
-                        console.log(`labTaskId = ${labTaskId}`);
                         const needIndex = this.homeroom.memory.labTasks[labTaskId].needs.findIndex((need) => need.resource === nextNeed.resource);
-                        console.log(`needIndex = ${needIndex}`);
                         if (needIndex > -1) {
                             this.homeroom.memory.labTasks[labTaskId].needs[needIndex].amount -= amountToTransfer;
                             this.memory.labNeeds[0].amount -= amountToTransfer;

--- a/src/virtualCreeps/transportCreep.ts
+++ b/src/virtualCreeps/transportCreep.ts
@@ -138,6 +138,9 @@ export class TransportCreep extends WaveCreep {
 
             return;
         }
+
+        //if no source is found, use held resources
+        this.stopGathering();
     }
 
     protected findEnergySource(): Id<Structure> | Id<ConstructionSite> | Id<Creep> | Id<Resource> | Id<Tombstone> | Id<Ruin> {
@@ -153,9 +156,7 @@ export class TransportCreep extends WaveCreep {
             },
         });
 
-        const looseEnergyStacks = this.room
-            .find(FIND_DROPPED_RESOURCES)
-            .filter((res) => res.resourceType === RESOURCE_ENERGY && res.amount >= this.store.getCapacity());
+        const looseEnergyStacks = this.room.find(FIND_DROPPED_RESOURCES).filter((res) => res.resourceType === RESOURCE_ENERGY && res.amount);
         let containers = this.room.find(FIND_STRUCTURES).filter((str) => {
             let isAllowedStampContainer = true;
             // In Stamps do not allow retrieving energy from center/rm containers or miner containers with links

--- a/src/virtualCreeps/waveCreep.ts
+++ b/src/virtualCreeps/waveCreep.ts
@@ -113,7 +113,7 @@ export class WaveCreep extends Creep {
     }
 
     private getNextBoost() {
-        let nextBoostTask = this.room.memory.labTasks.find((task) => task.targetCreepName === this.name);
+        let nextBoostTask = Object.values(this.room.memory.labTasks).find((task) => task.targetCreepName === this.name);
         if (nextBoostTask) {
             let boostLab = Game.getObjectById(nextBoostTask.reactionLabs?.[0]);
             if (boostLab && nextBoostTask.status === TaskStatus.ACTIVE) {

--- a/src/virtualCreeps/waveCreep.ts
+++ b/src/virtualCreeps/waveCreep.ts
@@ -11,7 +11,11 @@ export class WaveCreep extends Creep {
         }
 
         if (this.memory.needsBoosted) {
-            this.getNextBoost();
+            if (!this.room.labs.length) {
+                delete this.memory.needsBoosted;
+            } else {
+                this.getNextBoost();
+            }
         } else if (this.memory.portalLocations?.[0]) {
             let portalPos = this.memory.portalLocations[0].toRoomPos();
 

--- a/src/virtualCreeps/workerCreep.ts
+++ b/src/virtualCreeps/workerCreep.ts
@@ -119,7 +119,7 @@ export class WorkerCreep extends WaveCreep {
         let buildSuccess = this.build(target);
         switch (buildSuccess) {
             case ERR_NOT_IN_RANGE:
-                this.travelTo(target, { range: 3, maxRooms: 1, exitCost: 10 });
+                this.travelTo(target, { range: 3, maxRooms: 1, exitCost: 10, avoidEdges: true });
                 break;
             case ERR_NOT_ENOUGH_RESOURCES:
                 this.memory.gathering = true;
@@ -127,6 +127,9 @@ export class WorkerCreep extends WaveCreep {
                 this.onTaskFinished();
                 break;
             case OK:
+                if (this.onEdge()) {
+                    this.travelTo(target);
+                }
                 if (this.isBuildFinished(target)) {
                     this.onTaskFinished();
                 }
@@ -171,9 +174,9 @@ export class WorkerCreep extends WaveCreep {
             let repairSuccess = this.repair(target);
             switch (repairSuccess) {
                 case ERR_NOT_IN_RANGE:
-                    const opts: TravelToOpts = { range: 3, maxRooms: 1 };
+                    const opts: TravelToOpts = { range: 3, maxRooms: 1, avoidEdges: true };
                     if (
-                        this.homeroom.memory.layout === RoomLayout.STAMP &&
+                        this.homeroom?.memory.layout === RoomLayout.STAMP &&
                         (this.room.memory.threatLevel === HomeRoomThreatLevel.ENEMY_INVADERS ||
                             this.room.memory.threatLevel >= HomeRoomThreatLevel.ENEMY_ATTTACK_CREEPS)
                     ) {
@@ -189,6 +192,9 @@ export class WorkerCreep extends WaveCreep {
                     this.onTaskFinished();
                     break;
                 case OK:
+                    if (this.onEdge()) {
+                        this.travelTo(target);
+                    }
                     if (this.isRepairFinished(target)) {
                         this.onTaskFinished();
                     }


### PR DESCRIPTION
Reworks the creation and distribution of resources:

## BREAKING CHANGES:
LabTasks in RoomMemory is changed from an Array to an Object (for faster & easier access to tasks via Id). This must be manually changed before deploying, or else you'll have confusing error messages. Simply delete labTasks in roomMemory and it will be reinitialized correctly.

## Changes

### Resource requests
Adds a new memory type that rooms can use to _request_ resources they need. Each tick, _ResourceManagement_ goes through the list of requests and creates outbound shipments in rooms that can supply the resource. 

One use case of this feature: on-the-fly requests for available boost resources needed to spawn creeps. Rooms can now spawn creeps that they don't contain enough resources to boost in local storage; they'll submit a resource request at spawn time and the resources (if available) will be supplied by other rooms.

### Room resource inventory tweaks
Changes the resources that are kept in the terminal. Now, the terminal will be used to store 5k of all minerals and mineral compounds. Any excess is stored in room storage. **No energy is kept in the terminal**. When a shipment is worked, the manager will add energy as required. Additionally, rooms will reserve 20k of each Tier-3 boost, rather than just 5k. 

### Factory operation
Factory operation has been moved from _ResourceManagement_ to _RoomManagement_. Rooms will create batteries once they contain 375k or more energy, until they have 100k or more batteries in storage. Additionally, rooms will now compress extra minerals they have beyond 20k, and will decompress minerals if they have less than 5k uncompressed. Compressed minerals are considered in global resource needs calculation.

### Lab operation
Lab task creation and assignment has been modified:
- Boosts will no longer use Tier-1 or Tier-2 boost resources.  
- Rooms will only run up to one React task. The two center labs will always be reserved and used as supply for reactants.
- Idle labs will be automatically assigned to the current react task (if any).
- When a boost task is needed, labs can be unassigned from their current React task and repurposed for boosting. This way, boost tasks won't be blocked by a react task.
- More than one boost task of the same type (Build, Heal, etc) can be assigned to one lab. This keeps labs free for more boost types or reactions.